### PR TITLE
[#11] Common DataResponseDto 추가

### DIFF
--- a/server/src/main/java/com/genesisairport/reservation/common/DataResponseDto.java
+++ b/server/src/main/java/com/genesisairport/reservation/common/DataResponseDto.java
@@ -1,0 +1,31 @@
+package com.genesisairport.reservation.common;
+
+import lombok.Getter;
+
+@Getter
+public class DataResponseDto<T> extends ResponseDto {
+
+    private final T data;
+
+    private DataResponseDto(T data) {
+        super(true, ResponseCode.OK.getCode(), ResponseCode.OK.getMessage());
+        this.data = data;
+    }
+
+    private DataResponseDto(T data, String message) {
+        super(true, ResponseCode.OK.getCode(), message);
+        this.data = data;
+    }
+
+    public static <T> DataResponseDto<T> of(T data) {
+        return new DataResponseDto<>(data);
+    }
+
+    public static <T> DataResponseDto<T> of(T data, String message) {
+        return new DataResponseDto<>(data, message);
+    }
+
+    public static <T> DataResponseDto<T> empty() {
+        return new DataResponseDto<>(null);
+    }
+}

--- a/server/src/main/java/com/genesisairport/reservation/common/ResponseCode.java
+++ b/server/src/main/java/com/genesisairport/reservation/common/ResponseCode.java
@@ -1,0 +1,55 @@
+package com.genesisairport.reservation.common;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+@Getter
+@RequiredArgsConstructor
+public enum ResponseCode {
+
+    OK(0, HttpStatus.OK, "Ok"),
+
+    BAD_REQUEST(400, HttpStatus.BAD_REQUEST, "Bad request"),
+
+    INTERNAL_ERROR(500, HttpStatus.INTERNAL_SERVER_ERROR, "Internal error");
+
+    private final Integer code;
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    public String getMessage(Throwable e) {
+        return this.getMessage(this.getMessage() + " - " + e.getMessage());
+        // 결과 예시 - "Validation error - Reason why it isn't valid"
+    }
+
+    public String getMessage(String message) {
+        return Optional.ofNullable(message)
+                .filter(Predicate.not(String::isBlank))
+                .orElse(this.getMessage());
+    }
+
+    public static ResponseCode valueOf(HttpStatus httpStatus) {
+        return Arrays.stream(values())
+                .filter(errorCode -> errorCode.getHttpStatus() == httpStatus)
+                .findFirst()
+                .orElseGet(() -> {
+                    if (httpStatus.is4xxClientError()) {
+                        return ResponseCode.BAD_REQUEST;
+                    } else if (httpStatus.is5xxServerError()) {
+                        return ResponseCode.INTERNAL_ERROR;
+                    } else {
+                        return ResponseCode.OK;
+                    }
+                });
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s (%d)", this.name(), this.getCode());
+    }
+}

--- a/server/src/main/java/com/genesisairport/reservation/common/ResponseDto.java
+++ b/server/src/main/java/com/genesisairport/reservation/common/ResponseDto.java
@@ -1,0 +1,29 @@
+package com.genesisairport.reservation.common;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@RequiredArgsConstructor
+public class ResponseDto {
+
+    private final Boolean success;
+
+    private final Integer code;
+
+    private final String message;
+
+    public static ResponseDto of(Boolean success, ResponseCode code) {
+        return new ResponseDto(success, code.getCode(), code.getMessage());
+    }
+
+    public static ResponseDto of(Boolean success, ResponseCode errorCode, Exception e) {
+        return new ResponseDto(success, errorCode.getCode(), errorCode.getMessage(e));
+    }
+
+    public static ResponseDto of(Boolean success, ResponseCode errorCode, String message) {
+        return new ResponseDto(success, errorCode.getCode(), errorCode.getMessage(message));
+    }
+}


### PR DESCRIPTION
## 📎 PR 제목
[#11] Common DataResponseDto 추가

## 📎 작업 내용
- DataResponseDto 추가
    - ex) return DataResponseDto.of(new TestDto("test")); 이런 식으로 사용하면 data 칸에 원하는 Dto를 감싸서 전달 가능합니다.

## 📎 필요한 후속 작업 
- data 없거나 문제 있을 때 exception을 추가해야 하나, Exception handling 정책이 아직 없어서 안 넣었음. 추후에 추가해주세요.