### PR TITLE
[# 30] 예약내역리스트 api가 더미 데이터를 반환

### DIFF
--- a/server/src/main/java/com/genesisairport/reservation/Response/ReservationListAbstract.java
+++ b/server/src/main/java/com/genesisairport/reservation/Response/ReservationListAbstract.java
@@ -1,0 +1,25 @@
+package com.genesisairport.reservation.Response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ReservationListAbstract {
+    private List<ReservationAbstract> reservationList;
+
+    @Getter
+    @Builder
+    public static class ReservationAbstract{
+        private long reservationId;
+        private String from;
+        private String to;
+        private String progressStage;
+        private String carSellName;
+        private String carPlateNumber;
+        private String repairShop;
+        private String repairShopAddress;
+    }
+}

--- a/server/src/main/java/com/genesisairport/reservation/controller/ReservationController.java
+++ b/server/src/main/java/com/genesisairport/reservation/controller/ReservationController.java
@@ -1,5 +1,6 @@
 package com.genesisairport.reservation.controller;
 
+import com.genesisairport.reservation.Response.ReservationListAbstract;
 import com.genesisairport.reservation.Response.ReservationPostResponse;
 import com.genesisairport.reservation.common.DataResponseDto;
 import com.genesisairport.reservation.service.ReservationService;
@@ -52,5 +53,14 @@ public class ReservationController {
         log.debug("예약 정보 저장");
 
         return new ResponseEntity<>(DataResponseDto.of(reservationService.reserve(requestBody)), HttpStatus.OK);
+    }
+
+    @GetMapping("/list")
+    public ResponseEntity<DataResponseDto<ReservationListAbstract>> getReservationList() {
+        log.debug("특정 사용자 예약 내역 조회");
+
+        ReservationListAbstract reservationList = reservationService.getReservationList();
+
+        return new ResponseEntity<>(DataResponseDto.of(reservationList), HttpStatus.OK);
     }
 }

--- a/server/src/main/java/com/genesisairport/reservation/service/ReservationService.java
+++ b/server/src/main/java/com/genesisairport/reservation/service/ReservationService.java
@@ -1,6 +1,7 @@
 package com.genesisairport.reservation.service;
 
 
+import com.genesisairport.reservation.Response.ReservationListAbstract;
 import com.genesisairport.reservation.Response.ReservationPostResponse;
 import com.genesisairport.reservation.Response.ReservationResponse;
 import com.genesisairport.reservation.Response.ReservationDateResponse;
@@ -112,5 +113,51 @@ public class ReservationService {
                 .from(fromDateTime)
                 .to(toDateTime)
                 .build();
+    }
+
+    public ReservationListAbstract getReservationList() {
+        // 예약 내역 리스트 생성 (임의로 데이터 생성)
+        List<ReservationListAbstract.ReservationAbstract> reservationList = new ArrayList<>();
+
+        // 첫 번째 예약 내역
+        ReservationListAbstract.ReservationAbstract reservation1 = ReservationListAbstract.ReservationAbstract.builder()
+                .reservationId(1)
+                .from("2024-03-01 14:00:00")
+                .to("2024-03-07 20:00:00")
+                .progressStage("예약")
+                .carSellName("Genesis G90")
+                .carPlateNumber("00ㅁ 0000")
+                .repairShop("블루핸즈 인천공항점")
+                .repairShopAddress("인천 중구 용유서로172번길 56 블루핸즈 인천공항점")
+                .build();
+        reservationList.add(reservation1);
+
+        // 두 번째 예약 내역
+        ReservationListAbstract.ReservationAbstract reservation2 = ReservationListAbstract.ReservationAbstract.builder()
+                .reservationId(2)
+                .from("2024-03-10 09:00:00")
+                .to("2024-03-15 18:00:00")
+                .progressStage("접수")
+                .carSellName("Genesis G90")
+                .carPlateNumber("00ㅂ 1111")
+                .repairShop("블루핸즈 인천공항점")
+                .repairShopAddress("인천 중구 용유서로172번길 56 블루핸즈 인천공항점")
+                .build();
+        reservationList.add(reservation2);
+
+        // 세 번째 예약 내역
+        ReservationListAbstract.ReservationAbstract reservation3 = ReservationListAbstract.ReservationAbstract.builder()
+                .reservationId(3)
+                .from("2024-03-20 13:30:00")
+                .to("2024-03-25 16:00:00")
+                .progressStage("점검중")
+                .carSellName("Genesis G90")
+                .carPlateNumber("00ㅇ 2222")
+                .repairShop("블루핸즈 인천공항점")
+                .repairShopAddress("인천 중구 용유서로172번길 56 블루핸즈 인천공항점")
+                .build();
+        reservationList.add(reservation3);
+
+        return ReservationListAbstract.builder().reservationList(reservationList).build();
     }
 }


### PR DESCRIPTION
## 📎 PR 제목
예약내역리스트 api가 더미 데이터를 반환

## 📎 작업 내용
`/v1/reservation/list`로 접근 시 api 명세에 작성한 예시 데이터를 반환하도록 구현

## 📎 필요한 후속 작업 
- DB와 연동하여 실제 동작하는 API 개발

## 📎 실행 화면
<img width="1670" alt="스크린샷 2024-02-07 오후 5 38 53" src="https://github.com/softeerbootcamp-3rd/Team10-GENE10S/assets/47194825/e7aad452-0f05-4604-ba44-ba08dd934c8f">
