### PR TITLE
[#37] 예약 완료 페이지 ui 구현

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["react-app", "plugin:prettier"],
+  "extends": ["react-app", "prettier"],
   "rules": {
     "no-var": "warn", // var 금지
     "no-multiple-empty-lines": "warn", // 여러 줄 공백 금지

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["react-app", "plugin:prettier/recommended"],
+  "extends": ["react-app", "plugin:prettier"],
   "rules": {
     "no-var": "warn", // var 금지
     "no-multiple-empty-lines": "warn", // 여러 줄 공백 금지

--- a/client/.prettierrc.json
+++ b/client/.prettierrc.json
@@ -1,4 +1,5 @@
 {
+  "printWidth": 120,
   "tabWidth": 2,
   "endOfLine": "lf",
   "arrowParens": "avoid",

--- a/client/.vscode/settings.json
+++ b/client/.vscode/settings.json
@@ -11,5 +11,6 @@
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "files.autoSave": "onFocusChange"
+  "files.autoSave": "onFocusChange",
+  "prettier.printWidth": 120
 }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -23,7 +23,6 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
-        "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
         "prettier": "^3.2.5"
       }
@@ -7599,6 +7598,8 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },

--- a/client/package.json
+++ b/client/package.json
@@ -42,7 +42,6 @@
     ]
   },
   "devDependencies": {
-    "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "prettier": "^3.2.5"
   }

--- a/client/src/assets/row-separator.svg
+++ b/client/src/assets/row-separator.svg
@@ -1,0 +1,5 @@
+<svg width="12" height="2" viewBox="0 0 12 2" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="row_separator">
+<line id="row_separator_2" y1="1" x2="12" y2="1" stroke="#B6B0A8" stroke-width="2"/>
+</g>
+</svg>

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -7,6 +7,7 @@ import NotFound from './pages/NotFound';
 import Reservation from './pages/Reservation';
 import Bot from './pages/Bot';
 import Mypage from './pages/Mypage';
+import ReservationComplete from './pages/ReservationComplete';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
@@ -14,6 +15,7 @@ root.render(
     <Routes>
       <Route path="/" element={<Main />} />
       <Route path="/reservation" element={<Reservation />} />
+      <Route path="/reservation/complete" element={<ReservationComplete />} />
       <Route path="/bot" element={<Bot />} />
       <Route path="/mypage" element={<Mypage />} />
       <Route path="*" element={<NotFound />} />

--- a/client/src/pages/ReservationComplete.js
+++ b/client/src/pages/ReservationComplete.js
@@ -50,7 +50,7 @@ export default function ReservationComplete() {
           </div>
         </div>
 
-        <div className={classNames('reservation-complete__line')}> - </div>
+        <div className={classNames('row--seperator')} />
 
         <div className={classNames('row')}>
           <div className={classNames('row--title')}>에약 차량</div>
@@ -66,7 +66,7 @@ export default function ReservationComplete() {
           </div>
         </div>
 
-        <div className={classNames('reservation-complete__line')}> - </div>
+        <div className={classNames('row--seperator')} />
 
         <div className={classNames('row')}>
           <div className={classNames('row--title')}>방문 센터</div>
@@ -86,7 +86,7 @@ export default function ReservationComplete() {
           </div>
         </div>
 
-        <div className={classNames('reservation-complete__line')}> - </div>
+        <div className={classNames('row--seperator')} />
 
         <div className={classNames('row')}>
           <div className={classNames('row--title')}>선택 서비스</div>

--- a/client/src/pages/ReservationComplete.js
+++ b/client/src/pages/ReservationComplete.js
@@ -1,0 +1,134 @@
+import classNames from 'classnames';
+import Footer from '../components/Footer';
+import Header from '../components/Header';
+
+export default function ReservationComplete() {
+  const username = 'user';
+  const reservDate = '2024년 1월 11일';
+  const reservTime = '10:00';
+  const pickupDate = '2024년 1월 14일';
+  const pickupTime = '17:00';
+  const carSellName = 'Genesis G80';
+  const carNumber = '12가 3456';
+  const shopName = '블루헨즈 인천공항점';
+  const shopAddress = '인천 중구 용유서로 172번길';
+  const shopPhoneNumber = '010-1234-1234';
+  const request = '에어컨이 고장났어요.';
+  const notSelected = true;
+
+  return (
+    <>
+      <Header />
+      <div className={classNames('content', 'reservation-complete')}>
+        <div className={classNames('title')}>
+          <span className={classNames('title--text')}>Reservation</span>
+        </div>
+
+        <div className={classNames('info')}>
+          <div>
+            <span className={classNames('info--name')}>{username}</span>
+            <span>님, 다음 내용으로 예약 되었습니다.</span>
+          </div>
+          <div>
+            <span>예약일 </span>
+            <span className={classNames('outline')}>{reservDate}</span>
+            <span>까지 센터로 방문해주세요.</span>
+          </div>
+        </div>
+
+        <div className={classNames('row')}>
+          <div className={classNames('row--title')}>에약일</div>
+          <div className={classNames('row__content')}>
+            <div className={classNames('content__detail')}>
+              <span className={classNames('content__detail--name', 'outline')}>센터 방문</span>
+              <span>{`${reservDate} ${reservTime}`}</span>
+            </div>
+            <div className={classNames('content__detail')}>
+              <span className={classNames('content__detail--name', 'outline')}>픽업 시간</span>
+              <span>{`${pickupDate} ${pickupTime}`}</span>
+            </div>
+          </div>
+        </div>
+
+        <div className={classNames('reservation-complete__line')}> - </div>
+
+        <div className={classNames('row')}>
+          <div className={classNames('row--title')}>에약 차량</div>
+          <div className={classNames('row__content')}>
+            <div className={classNames('content__detail')}>
+              <span className={classNames('content__detail--name', 'outline')}>차종</span>
+              <span>{carSellName}</span>
+            </div>
+            <div className={classNames('content__detail')}>
+              <span className={classNames('content__detail--name', 'outline')}>차량 번호</span>
+              <span>{carNumber}</span>
+            </div>
+          </div>
+        </div>
+
+        <div className={classNames('reservation-complete__line')}> - </div>
+
+        <div className={classNames('row')}>
+          <div className={classNames('row--title')}>방문 센터</div>
+          <div className={classNames('row__content')}>
+            <div className={classNames('content__detail')}>
+              <span className={classNames('content__detail--name', 'outline')}>지점명</span>
+              <span>{shopName}</span>
+            </div>
+            <div className={classNames('content__detail')}>
+              <span className={classNames('content__detail--name', 'outline')}>주소</span>
+              <span>{shopAddress}</span>
+            </div>
+            <div className={classNames('content__detail')}>
+              <span className={classNames('content__detail--name', 'outline')}>연락처</span>
+              <span>{shopPhoneNumber}</span>
+            </div>
+          </div>
+        </div>
+
+        <div className={classNames('reservation-complete__line')}> - </div>
+
+        <div className={classNames('row')}>
+          <div className={classNames('row--title')}>선택 서비스</div>
+          <div className={classNames('row__content')}>
+            <div className={classNames('content__line')}>
+              <span>각종 오일 및 호스 상태</span>
+              <span className={classNames({ notSelected })}>배터리 상태 및 충전 전압</span>
+            </div>
+            <div className={classNames('content__line')}>
+              <span className={classNames({ notSelected })}>엔진 구동 상태</span>
+              <span>엔진 냉각수</span>
+              <span className={classNames({ notSelected })}>에어클리너 점검</span>
+            </div>
+            <div className={classNames('content__line')}>
+              <span>하체충격 및 손상 여부</span>
+              <span className={classNames({ notSelected })}>브레이크패드 및 라이닝 마모</span>
+            </div>
+            <div className={classNames('content__line')}>
+              <span>각종 등화 장치 점검</span>
+              <span>엔진 미션 마운트</span>
+              <span>서스펜션 뉴계토우 점검</span>
+            </div>
+            <div className={classNames('content__line')}>
+              <span className={classNames({ notSelected })}>스테빌라이저 및 드라이버 샤프트</span>
+              <span>스캐너 고장코드 진단</span>
+            </div>
+            <div className={classNames('content__line')}>
+              <span className={classNames({ notSelected })}>에어컨 및 히터 작동 생태</span>
+              <span>타이어 공기압 및 마모도</span>
+              <span className={classNames({ notSelected })}>에어컨 필터</span>
+            </div>
+          </div>
+        </div>
+
+        <div className={classNames('row')}>
+          <div className={classNames('row--title')}>요청 사항</div>
+          <span>{request}</span>
+        </div>
+
+        <button className={classNames('button')}>예약내역 확인하기</button>
+      </div>
+      <Footer />
+    </>
+  );
+}

--- a/client/src/styles/pages/reservComp.scss
+++ b/client/src/styles/pages/reservComp.scss
@@ -71,6 +71,13 @@
       text-align: center;
     }
 
+    &--seperator {
+      width: 12px;
+      height: 4px;
+      background-image: url('../../assets/row-separator.svg');
+      fill: $gray_200;
+    }
+
     &__content {
       display: flex;
       flex-direction: column;

--- a/client/src/styles/pages/reservComp.scss
+++ b/client/src/styles/pages/reservComp.scss
@@ -1,0 +1,120 @@
+@import '../variables.scss';
+
+.reservation-complete {
+  @extend %SB_18;
+  background-color: $white;
+  width: 1920px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  color: $black;
+  padding-bottom: 100px;
+
+  .outline {
+    @extend %B_18;
+    color: $orange_700;
+  }
+
+  .title {
+    display: flex;
+    width: 1700px;
+    flex-direction: column;
+    align-items: center;
+    padding-bottom: 40px;
+    padding-top: 52px;
+    border-bottom: 4px solid $black;
+
+    &--text {
+      @extend %B_48;
+      display: flex;
+      width: 452px;
+      height: 64px;
+      flex-direction: column;
+      justify-content: center;
+      text-align: center;
+    }
+  }
+
+  .info {
+    @extend %SB_18;
+    display: inline-flex;
+    padding: 32px 232px;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 32px;
+    margin-top: 28px;
+    color: $black;
+
+    &--name {
+      @extend %B_18;
+    }
+  }
+
+  .row {
+    display: flex;
+    width: 912px;
+    padding: 8px 24px;
+    align-items: center;
+    gap: 64px;
+
+    &--title {
+      @extend %B_24;
+      display: flex;
+      width: 200px;
+      height: 100px;
+      padding: 24px 0px;
+      justify-content: center;
+      align-items: center;
+      gap: 12px;
+      flex-shrink: 0;
+      text-align: center;
+    }
+
+    &__content {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: flex-start;
+
+      .content__detail {
+        display: flex;
+        height: 64px;
+        padding: 0px 48px 0px 24px;
+        align-items: center;
+        gap: 56px;
+
+        &--name {
+          width: 100px;
+          text-align: center;
+        }
+      }
+
+      .content__line {
+        display: flex;
+        padding: 24px;
+        align-items: center;
+        align-content: center;
+        gap: 24px 36px;
+        align-self: stretch;
+        flex-wrap: wrap;
+
+        .notSelected {
+          color: $gray_200;
+        }
+      }
+    }
+  }
+
+  .button {
+    @extend %SB_18;
+    width: 400px;
+    height: 48px;
+    flex-shrink: 0;
+    border: 2px solid $gray_900;
+    background: $white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+}

--- a/client/src/styles/styles.scss
+++ b/client/src/styles/styles.scss
@@ -3,6 +3,7 @@
 @import './components/footer.scss';
 @import './components/header.scss';
 @import './pages/main.scss';
+@import './pages/reservComp.scss';
 
 body {
   background-color: $black;

--- a/client/src/styles/variables.scss
+++ b/client/src/styles/variables.scss
@@ -35,7 +35,7 @@ $line_height_22: 22px;
 $line_height_20: 20px;
 
 $font_weight_bold: 700;
-$font_weight_semi_bold: 700;
+$font_weight_semi_bold: 600;
 $font_weight_medium: 500;
 $font_weight_regular: 400;
 


### PR DESCRIPTION
## 📎 PR 제목

개발 환경 수정 및 예약 완료 페이지 ui 구현

## 📎 작업 내용

- 공식적으로 권장되지 않는 eslint-plugin-prettier 제거
- 가독성을 위해 한 줄에 120자까지 표시되도록 설정 파일 수정
- 예약 완료 페이지 ui 구현

## 📎 필요한 후속 작업 

- 예약 페이지에서 변수를 넘겨받는 기능 추가
- 선택 서비스를 동적으로 보여줄 수 있도록 구현
- "예약내역 확인하기" 버튼에 기능 추가

## 📎 실행 화면

![image](https://github.com/softeerbootcamp-3rd/Team10-GENE10S/assets/66552990/3ab07d43-ebeb-4bd3-b1da-1e2dabfa30db)

<img width="1728" alt="image" src="https://github.com/softeerbootcamp-3rd/Team10-GENE10S/assets/66552990/dd536c1a-564a-4a33-8284-4233870e45ca">
