### PR TITLE
[#42] 예약 가능한 날짜 조회 API 수정

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -8,7 +8,6 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.2.2'
 	id 'io.spring.dependency-management' version '1.1.4'
-	id "com.ewerk.gradle.plugins.querydsl" version '1.0.10'
 }
 
 group = 'com.genesis-airport'
@@ -39,7 +38,9 @@ dependencies {
 
 	//querydsl
 	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
-	implementation "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
+	annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
 	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 }
@@ -48,29 +49,17 @@ tasks.named('test') {
 	useJUnitPlatform()
 }
 
+
 def querydslDir = "$buildDir/generated/querydsl"
 
-
-querydsl {
-	jpa = true
-	querydslSourcesDir = querydslDir
-}
-
-
 sourceSets {
-	main.java.srcDir querydslDir
+	main.java.srcDirs += [ querydslDir ]
 }
 
-
-
-compileQuerydsl {
-	options.annotationProcessorPath = configurations.querydsl
+tasks.withType(JavaCompile) {
+	options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
 }
 
-
-configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
-	querydsl.extendsFrom compileClasspath
+clean.doLast {
+	file(querydslDir).deleteDir()
 }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -1,7 +1,14 @@
+buildscript {
+	ext {
+		queryDslVersion = "5.0.0"
+	}
+}
+
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.2.2'
 	id 'io.spring.dependency-management' version '1.1.4'
+	id "com.ewerk.gradle.plugins.querydsl" version '1.0.10'
 }
 
 group = 'com.genesis-airport'
@@ -29,8 +36,41 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	//querydsl
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
+	implementation "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
+
+	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+
+querydsl {
+	jpa = true
+	querydslSourcesDir = querydslDir
+}
+
+
+sourceSets {
+	main.java.srcDir querydslDir
+}
+
+
+
+compileQuerydsl {
+	options.annotationProcessorPath = configurations.querydsl
+}
+
+
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+	querydsl.extendsFrom compileClasspath
 }

--- a/server/src/main/java/com/genesisairport/reservation/config/QuerydslConfig.java
+++ b/server/src/main/java/com/genesisairport/reservation/config/QuerydslConfig.java
@@ -1,0 +1,20 @@
+package com.genesisairport.reservation.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+}

--- a/server/src/main/java/com/genesisairport/reservation/controller/ReservationController.java
+++ b/server/src/main/java/com/genesisairport/reservation/controller/ReservationController.java
@@ -50,7 +50,7 @@ public class ReservationController {
     }
 
     @GetMapping("/available")
-    public ResponseEntity getAvailableDate(@RequestParam(required = true) String repairShop) {
+    public ResponseEntity getAvailableDates(@RequestParam(required = true) String repairShop) {
         log.debug("예약 가능 날짜 확인 API");
 
         return new ResponseEntity(

--- a/server/src/main/java/com/genesisairport/reservation/controller/ReservationController.java
+++ b/server/src/main/java/com/genesisairport/reservation/controller/ReservationController.java
@@ -49,11 +49,14 @@ public class ReservationController {
         );
     }
 
-    @GetMapping("/available/{repair_shop}")
-    public ResponseEntity<DataResponseDto<Map<String, List<ReservationDateResponse>>>> getAvailableDate() {
+    @GetMapping("/available")
+    public ResponseEntity getAvailableDate(@RequestParam(required = true) String repairShop) {
         log.debug("예약 가능 날짜 확인 API");
 
-        return new ResponseEntity<>(DataResponseDto.of(reservationService.getAvailableDates()), HttpStatus.OK);
+        return new ResponseEntity(
+                DataResponseDto.of(reservationService.getAvailableDates(repairShop)),
+                HttpStatus.OK
+        );
     }
 
     @PostMapping("/")

--- a/server/src/main/java/com/genesisairport/reservation/entity/RepairShop.java
+++ b/server/src/main/java/com/genesisairport/reservation/entity/RepairShop.java
@@ -21,7 +21,7 @@ public class RepairShop {
     private Long id;
 
     @Column(name = "repair_shop", nullable = false, length = 20)
-    private String repairShop;
+    private String shopName;
 
     @Column(name = "capacity_per_time")
     private Integer capacityPerTime;

--- a/server/src/main/java/com/genesisairport/reservation/response/ReservationResponse.java
+++ b/server/src/main/java/com/genesisairport/reservation/response/ReservationResponse.java
@@ -3,6 +3,10 @@ package com.genesisairport.reservation.response;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.sql.Time;
+import java.util.Date;
+import java.util.List;
+
 public class ReservationResponse {
 
     public interface CarInfo {
@@ -14,6 +18,20 @@ public class ReservationResponse {
     @Builder
     public static class CouponValid {
         public boolean valid;
+    }
+
+    @Getter
+    @Builder
+    public static class AvailableDate {
+        private String date;
+        private List<TimeInfo> timeSlots;
+    }
+
+    @Getter
+    @Builder
+    public static class TimeInfo {
+        private Integer time;
+        private Boolean available;
     }
 
 }

--- a/server/src/main/java/com/genesisairport/reservation/respository/RepairShopRepository.java
+++ b/server/src/main/java/com/genesisairport/reservation/respository/RepairShopRepository.java
@@ -1,0 +1,7 @@
+package com.genesisairport.reservation.respository;
+
+import com.genesisairport.reservation.entity.RepairShop;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RepairShopRepository extends JpaRepository<RepairShop, Long>, RepairShopRepositoryCustom {
+}

--- a/server/src/main/java/com/genesisairport/reservation/respository/RepairShopRepositoryCustom.java
+++ b/server/src/main/java/com/genesisairport/reservation/respository/RepairShopRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.genesisairport.reservation.respository;
+
+import com.genesisairport.reservation.response.ReservationResponse;
+
+import java.util.List;
+
+public interface RepairShopRepositoryCustom {
+
+    public List<ReservationResponse.AvailableDate> findAvailableTimes(String shopName);
+
+}

--- a/server/src/main/java/com/genesisairport/reservation/respository/RepairShopRepositoryImpl.java
+++ b/server/src/main/java/com/genesisairport/reservation/respository/RepairShopRepositoryImpl.java
@@ -24,6 +24,7 @@ public class RepairShopRepositoryImpl implements RepairShopRepositoryCustom {
     @Override
     public List<ReservationResponse.AvailableDate> findAvailableTimes(String shopName) {
         LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        LocalDate twoWeeksLater = today.plusWeeks(2);
         LocalDate twoMonthsLater = today.plusMonths(2);
 
         List<Tuple> tuples = jpaQueryFactory
@@ -37,7 +38,7 @@ public class RepairShopRepositoryImpl implements RepairShopRepositoryCustom {
                 .innerJoin(availableTime).on(availableTime.repairShop.eq(repairShop))
                 .where(repairShop.shopName.eq(shopName)
                         .and(availableTime.reservationDate
-                                .between(Date.valueOf(today), Date.valueOf(twoMonthsLater))))
+                                .between(Date.valueOf(twoWeeksLater), Date.valueOf(twoMonthsLater))))
                 .orderBy(availableTime.reservationTime.asc())
                 .fetch();
 

--- a/server/src/main/java/com/genesisairport/reservation/respository/RepairShopRepositoryImpl.java
+++ b/server/src/main/java/com/genesisairport/reservation/respository/RepairShopRepositoryImpl.java
@@ -1,0 +1,75 @@
+package com.genesisairport.reservation.respository;
+
+import com.genesisairport.reservation.response.ReservationResponse;
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.sql.Date;
+import java.sql.Time;
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static com.genesisairport.reservation.entity.QRepairShop.repairShop;
+import static com.genesisairport.reservation.entity.QAvailableTime.availableTime;
+
+@RequiredArgsConstructor
+public class RepairShopRepositoryImpl implements RepairShopRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<ReservationResponse.AvailableDate> findAvailableTimes(String shopName) {
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        LocalDate twoMonthsLater = today.plusMonths(2);
+
+        List<Tuple> tuples = jpaQueryFactory
+                .select(
+                    availableTime.reservationDate,
+                    availableTime.reservationTime,
+                    availableTime.reservationCount,
+                    repairShop.capacityPerTime
+                )
+                .from(repairShop)
+                .innerJoin(availableTime).on(availableTime.repairShop.eq(repairShop))
+                .where(repairShop.shopName.eq(shopName)
+                        .and(availableTime.reservationDate
+                                .between(Date.valueOf(today), Date.valueOf(twoMonthsLater))))
+                .orderBy(availableTime.reservationTime.asc())
+                .fetch();
+
+        return convertToDto(tuples);
+    }
+
+    private List<ReservationResponse.AvailableDate> convertToDto(List<Tuple> tuples) {
+        Map<String, List<ReservationResponse.TimeInfo>> map = new HashMap<>();
+
+        for (Tuple t : tuples) {
+            Date date = t.get(0, Date.class);
+            String formattedDate = new SimpleDateFormat("yyyy-MM-dd").format(date);
+            Integer hour = t.get(1, Time.class).toLocalTime().getHour();
+            int cnt = t.get(2, Integer.class);
+            int capacity = t.get(3, Integer.class);
+
+            ReservationResponse.TimeInfo timeInfo = ReservationResponse.TimeInfo.builder()
+                    .time(hour)
+                    .available(cnt < capacity)
+                    .build();
+
+            map.computeIfAbsent(formattedDate, k -> new ArrayList<>()).add(timeInfo);
+        }
+
+        List<ReservationResponse.AvailableDate> availableDates = map.entrySet().stream()
+                .map(entry -> ReservationResponse.AvailableDate.builder()
+                        .date(entry.getKey())
+                        .timeSlots(entry.getValue())
+                        .build())
+                .collect(Collectors.toList());
+
+        Collections.reverse(availableDates);
+        return availableDates;
+    }
+}

--- a/server/src/main/java/com/genesisairport/reservation/service/ReservationService.java
+++ b/server/src/main/java/com/genesisairport/reservation/service/ReservationService.java
@@ -8,12 +8,14 @@ import com.genesisairport.reservation.respository.CarRepository;
 import com.genesisairport.reservation.Response.ReservationListAbstract;
 import com.genesisairport.reservation.respository.CouponRepository;
 
+import com.genesisairport.reservation.respository.RepairShopRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -27,6 +29,7 @@ public class ReservationService {
 
     private final CarRepository carRepository;
     private final CouponRepository couponRepository;
+    private final RepairShopRepository repairShopRepository;
 
     public Boolean validateCoupon(String serialNumber) {
         return couponRepository.existsBySerialNumber(serialNumber);
@@ -38,24 +41,9 @@ public class ReservationService {
         return carInfoList.isEmpty() ? null : carInfoList;
     }
 
-    public Map<String, List<ReservationDateResponse>> getAvailableDates() {
-        List<ReservationDateResponse> availableDates = new ArrayList<>();
-
-        // 예시로 임의의 데이터를 생성
-        LocalDate currentDate = LocalDate.now();
-        for (int i = 0; i < 5; i++) {
-            LocalDate date = currentDate.plusDays(i);
-            ReservationDateResponse availableDate = ReservationDateResponse.builder()
-                    .date(date.toString())
-                    .timeSlots(generateTimeSlots())
-                    .build();
-            availableDates.add(availableDate);
-        }
-
-        Map<String, List<ReservationDateResponse>> map = new HashMap<>();
-        map.put("available_reservation_lsit", availableDates);
-
-        return map;
+    public List<ReservationResponse.AvailableDate> getAvailableDates(String shopName) {
+        List<ReservationResponse.AvailableDate> availableDates = repairShopRepository.findAvailableTimes(shopName);
+        return availableDates.isEmpty() ? null : availableDates;
     }
 
     private List<ReservationDateResponse.TimeSlot> generateTimeSlots() {


### PR DESCRIPTION
## 📎 PR 제목

**GET /v1/reservation/available**
예약 가능 날짜 조회 API 실제 로직으로 변경

## 📎 작업 내용
1. Querydsl 세팅

2. Querydsl 적용

3. 예약 가능 날짜 조회 API 수정


## 📎 변경 로직
1. **Querydsl 세팅**
   - build.gradle 수정
   - QuerydslConfig 클래스 생성
 
2. **Querydsl 적용**
    - RepairShopRepository, RepairShopRepositoryCustom, RepairShopRepositoryImpl 생성
    - 지점명(shopName)을 request로 받아 해당 이름으로 지점의 예약 가능 날짜 검색하는 함수 구현
  
3. **예약 가능 날짜 조회 API 수정**
    - 더미가 아닌 실제 로직으로 변경
    - ReservationController : **getAvailableDates()**
    - ReservationService : **getAvailableDates()**

## 📎 필요한 후속 작업 

반환하는 데이터의 양이 많아 다음 두 가지 작업 중 하나를 선택해야 할 거 같습니다.

1.  API 분리하기
    - 특정 기간에 대해, 해당 날짜에 예약 가능한 시간이 존재하는지 아닌지만 조회하는 API
    - 특정 날짜에 대해, 모든 시간대에 대해 예약이 가능한지 아닌지 조회하는 API
 
2. 페이지네이션 적용

## 📎 실행 화면

### DB에 데이터 존재할 때

(일단 이틀간의 데이터만 임시로 넣었습니다)

<img width="931" alt="image" src="https://github.com/softeerbootcamp-3rd/Team10-GENE10S/assets/48647199/525c2b13-251d-483e-9c7a-571f83158d7f">

