### PR TITLE
[#173] 달력에서 예약 가능한 날짜만 선택 가능하게 변경

### DIFF
--- a/client/src/api/ReservationApi.js
+++ b/client/src/api/ReservationApi.js
@@ -1,6 +1,18 @@
 import axios from 'axios';
 import { formatDate } from '../utils/dateUtils';
 
+export async function getAvailableDate() {
+  try {
+    const response = await axios.get('/v1/reservation/date', {
+      params: { repairShop: '블루핸즈 인천공항점' }
+    })
+
+    return response.data.data;
+  } catch (error) {
+    console.error(error);
+  }
+}
+
 export async function getAvailableTime(year, month, day) {
   try {
     const response = await axios.get('/v1/reservation/time', {

--- a/client/src/components/Calendar.js
+++ b/client/src/components/Calendar.js
@@ -1,6 +1,8 @@
 import classNames from 'classnames';
+import { formatDate } from '../utils/dateUtils';
 
-export default function Calendar({ year, month, day, handleClickDate, handleLastMonth, handleNextMonth }) {
+export default function Calendar({ year, month, day, availableDates,
+  handleClickDate, handleLastMonth, handleNextMonth }) {
   const getLastDayOfMonth = (year, month) => {
     return new Date(year, month + 1, 0).getDate();
   };
@@ -39,6 +41,7 @@ export default function Calendar({ year, month, day, handleClickDate, handleLast
       weeks.push(
         <div key={i} className={classNames('week')}>
           {weekDates.map((date, index) => {
+            const formattedDate = formatDate(new Date(year, month, date));
             return (
               <div
                 key={index}
@@ -46,9 +49,10 @@ export default function Calendar({ year, month, day, handleClickDate, handleLast
                   'atom-nothing': date == null,
                   'atom': date != null && index > 0 && index < 6,
                   'atom-weekday': date != null && (index === 0 || index === 6),
-                  'active': date != null && date === day
+                  'active': date != null && date === day,
+                  'disabled': !availableDates.includes(formattedDate)
                 })}
-                onClick={date != null ? () => handleClickDate(year, month, date) : null}
+                onClick={date != null && availableDates.includes(formattedDate) ? () => handleClickDate(year, month, date) : null}
               >
                 <span className={classNames('text')}>{date}</span>
               </div>

--- a/client/src/components/ModalDate.js
+++ b/client/src/components/ModalDate.js
@@ -1,9 +1,9 @@
 import classNames from 'classnames';
 import { BtnBlack } from './Button';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Calendar from './Calendar';
 import TimeSlots from './TimeSlots';
-import { getAvailableTime } from '../api/ReservationApi';
+import { getAvailableDate, getAvailableTime } from '../api/ReservationApi';
 
 export default function ModalDate({ nextStep, props, fadeIn }) {
 
@@ -20,6 +20,7 @@ export default function ModalDate({ nextStep, props, fadeIn }) {
   const [pickupDay, setPickupDay] = useState(props.pickupDay);
   const [pickupTime, setPickupTime] = useState(props.pickupTime);
 
+  const [availableDates, setAvailableDates] = useState([]);
   const [showTimes, setShowTimes] = useState(false);
   const [timeData, setTimeData] = useState(null);
   const [selectedTime, setSelectedTime] = useState(null);
@@ -29,6 +30,12 @@ export default function ModalDate({ nextStep, props, fadeIn }) {
   const [calendarYear, setCalendarYear] = useState(currentYear);
   const [calendarMonth, setCalendarMonth] = useState(currentMonth);
   const [calendarDay, setCalendarDay] = useState(null);
+
+  useEffect(() => {
+    getAvailableDate().then((result) => {
+      setAvailableDates(result.availableDates);
+    });
+  });
 
   const handleNext = () => {
     if (departureTime === '' || pickupTime === '') return;
@@ -157,7 +164,12 @@ export default function ModalDate({ nextStep, props, fadeIn }) {
     setCalendarYear(departureYear != null ? departureYear : currentYear);
     setCalendarMonth(departureMonth != null ? departureMonth : currentMonth);
     setCalendarDay(departureDay);
-    setShowTimes(false);
+    if (departureDay != null) {
+      getAvailableTime(departureYear, departureMonth, departureDay).then(result => {
+        setTimeData(result.timeSlots);
+        setShowTimes(true);
+      });
+    }
     setSelectedTime(departureTime);
   }
 
@@ -168,7 +180,12 @@ export default function ModalDate({ nextStep, props, fadeIn }) {
     setCalendarYear(pickupYear != null ? pickupYear : currentYear);
     setCalendarMonth(pickupMonth != null ? pickupMonth : currentMonth);
     setCalendarDay(pickupDay);
-    setShowTimes(false);
+    if (pickupDay != null) {
+      getAvailableTime(pickupYear, pickupMonth, pickupDay).then(result => {
+        setTimeData(result.timeSlots);
+        setShowTimes(true);
+      });
+    }
     setSelectedTime(pickupTime);
   }
 
@@ -180,6 +197,7 @@ export default function ModalDate({ nextStep, props, fadeIn }) {
             year={calendarYear}
             month={calendarMonth}
             day={calendarDay}
+            availableDates={availableDates}
             handleClickDate={handleClickDate}
             handleLastMonth={handleLastMonth}
             handleNextMonth={handleNextMonth}

--- a/client/src/styles/components/calendar.scss
+++ b/client/src/styles/components/calendar.scss
@@ -69,8 +69,8 @@
   transition: background-color 0.3s ease;
 }
 
-.calendar > .calendar-content > .week > .atom-weekday:hover,
-.calendar > .calendar-content > .week > .atom:hover {
+.calendar > .calendar-content > .week > .atom-weekday:not(.disabled):hover,
+.calendar > .calendar-content > .week > .atom:not(.disabled):hover {
   background: $orange_900;
   cursor: pointer;
 }
@@ -84,6 +84,14 @@
   color: $orange_500;
   text-align: center;
   @extend %B_24
+}
+
+.calendar > .calendar-content > .week > .atom-weekday.disabled > .text {
+  color: $orange_900;
+}
+
+.calendar > .calendar-content > .week > .atom.disabled > .text {
+  color: $gray_700;
 }
 
 .calendar > .calendar-content > .week-title > .atom > .text,

--- a/client/src/styles/pages/reservationModal.scss
+++ b/client/src/styles/pages/reservationModal.scss
@@ -263,6 +263,7 @@
 
   > .time-slot:not(.available) {
     display: flex;
+    width: 64px;
     padding: 8px 24px;
     justify-content: center;
     align-items: center;


### PR DESCRIPTION
## 📎 PR 제목
달력에서 예약 가능한 날짜만 선택 가능하게 변경

## 📎 작업 내용
- 예약 가능 시간 API 불러오는 코드 추가
- 예약 가능 시간에 있는 날짜라면 선택 가능, 아니라면 어두운 글자로 표시
