### PR TITLE
[#125] 예약상세 페이지 애니메이션 적용

### DIFF
--- a/client/src/components/reservation_detail/ReservationDetailInfo.js
+++ b/client/src/components/reservation_detail/ReservationDetailInfo.js
@@ -74,7 +74,7 @@ export default function ReservationDetailInfo({ reservationDetail }) {
             </div>
           </div>
           <div className={classNames('map')}>
-            <img className={classNames('basemap-image')} />
+            <img className={classNames('basemap-image')} alt='정비소 위치' />
           </div>
         </div>
       </div>
@@ -94,7 +94,7 @@ export default function ReservationDetailInfo({ reservationDetail }) {
               <div className={classNames('text-1')}>{reservationDetail.carSellName}</div>
               <div className={classNames('text-2')}>{reservationDetail.carPlateNumber}</div>
             </div>
-            <img src={reservationDetail.imageUrl} className={classNames('image-7')} />
+            <img src={reservationDetail.imageUrl} className={classNames('image-7')} alt='차량 대표 이미지' />
           </div>
         </div>
         {/* coupon-info */}

--- a/client/src/components/reservation_detail/ReservationDetailInfo.js
+++ b/client/src/components/reservation_detail/ReservationDetailInfo.js
@@ -94,7 +94,7 @@ export default function ReservationDetailInfo({ reservationDetail }) {
               <div className={classNames('text-1')}>{reservationDetail.carSellName}</div>
               <div className={classNames('text-2')}>{reservationDetail.carPlateNumber}</div>
             </div>
-            <img className={classNames('image-7')} />
+            <img src={reservationDetail.imageUrl} className={classNames('image-7')} />
           </div>
         </div>
         {/* coupon-info */}

--- a/client/src/components/reservation_detail/ReservationDetailResult.js
+++ b/client/src/components/reservation_detail/ReservationDetailResult.js
@@ -79,7 +79,7 @@ export default function ReservationDetailResult({ reservationDetail }) {
         </div>
         {/* image */}
         <div className={classNames('image')}>
-          <div className={classNames('arrow-left')} onClick={handleBeforePrev}>
+          <div className={classNames('arrow-left', { 'disabled': currentBeforeIndex === 0 })} onClick={handleBeforePrev}>
             <ProgressArrow200 />
           </div>
           <div className={classNames('image-wrapper')}>
@@ -96,7 +96,7 @@ export default function ReservationDetailResult({ reservationDetail }) {
               ))}
             </div>
           </div>
-          <div className={classNames('arrow-right')} onClick={handleBeforeNext}>
+          <div className={classNames('arrow-right', { 'disabled': currentBeforeIndex === beforeImages.length - 1 || beforeImages.length === 0 })} onClick={handleBeforeNext}>
             <ProgressArrow200 />
           </div>
         </div>
@@ -109,7 +109,7 @@ export default function ReservationDetailResult({ reservationDetail }) {
         </div>
         {/* image */}
         <div className={classNames('image')}>
-          <div className={classNames('arrow-left')} onClick={handleAfterPrev}>
+          <div className={classNames('arrow-left', { 'disabled': currentAfterIndex === 0 })} onClick={handleAfterPrev}>
             <ProgressArrow200 />
           </div>
           <div className={classNames('image-wrapper')}>
@@ -126,7 +126,7 @@ export default function ReservationDetailResult({ reservationDetail }) {
               ))}
             </div>
           </div>
-          <div className={classNames('arrow-right')} onClick={handleAfterNext}>
+          <div className={classNames('arrow-right', { 'disabled': currentAfterIndex === afterImages.length - 1 || afterImages.length === 0 })} onClick={handleAfterNext}>
             <ProgressArrow200 />
           </div>
         </div>

--- a/client/src/components/reservation_detail/ReservationDetailResult.js
+++ b/client/src/components/reservation_detail/ReservationDetailResult.js
@@ -83,7 +83,10 @@ export default function ReservationDetailResult({ reservationDetail }) {
             <ProgressArrow200 />
           </div>
           <div className={classNames('image-wrapper')}>
-            <div
+            { beforeImages.length === 0 ? (
+              <div className="no-image">점검 전 이미지가 없습니다.</div>
+            ) : (
+              <div
               className={classNames('images')}
               style={{
                 width: `${100}%`,
@@ -95,6 +98,7 @@ export default function ReservationDetailResult({ reservationDetail }) {
                 <img key={index} src={image} style={{ height: `400px` }} />
               ))}
             </div>
+            )}
           </div>
           <div className={classNames('arrow-right', { 'disabled': currentBeforeIndex === beforeImages.length - 1 || beforeImages.length === 0 })} onClick={handleBeforeNext}>
             <ProgressArrow200 />
@@ -113,7 +117,10 @@ export default function ReservationDetailResult({ reservationDetail }) {
             <ProgressArrow200 />
           </div>
           <div className={classNames('image-wrapper')}>
-            <div
+            { afterImages.length === 0 ? (
+              <div className="no-image">점검 후 이미지가 없습니다.</div>
+            ) : (
+              <div
               className={classNames('images')}
               style={{
                 width: `${100}%`,
@@ -125,6 +132,7 @@ export default function ReservationDetailResult({ reservationDetail }) {
                 <img key={index} src={image} style={{ height: `400px` }} />
               ))}
             </div>
+            )}
           </div>
           <div className={classNames('arrow-right', { 'disabled': currentAfterIndex === afterImages.length - 1 || afterImages.length === 0 })} onClick={handleAfterNext}>
             <ProgressArrow200 />

--- a/client/src/components/reservation_detail/ReservationDetailResult.js
+++ b/client/src/components/reservation_detail/ReservationDetailResult.js
@@ -95,7 +95,7 @@ export default function ReservationDetailResult({ reservationDetail }) {
               }}
             >
               {beforeImages.map((image, index) => (
-                <img key={index} src={image} style={{ height: `400px` }} />
+                <img key={index} src={image} alt={'before-'+index} style={{ height: `400px` }} />
               ))}
             </div>
             )}
@@ -129,7 +129,7 @@ export default function ReservationDetailResult({ reservationDetail }) {
               }}
             >
               {afterImages.map((image, index) => (
-                <img key={index} src={image} style={{ height: `400px` }} />
+                <img key={index} src={image} alt={'after-'+index} style={{ height: `400px` }} />
               ))}
             </div>
             )}

--- a/client/src/pages/ReservationDetail.js
+++ b/client/src/pages/ReservationDetail.js
@@ -14,9 +14,11 @@ export default function ReservationDetail() {
   const location = useLocation();
   const [reservationId, setReservationId] = useState(null);
   const [reservationDetail, setReservationDetail] = useState({});
+  const [fadeIn, setFadeIn] = useState(false);
 
   useEffect(() => {
     window.scrollTo(0, 0);
+    setFadeIn(true);
   }, []);
 
   useEffect(() => {
@@ -40,7 +42,7 @@ export default function ReservationDetail() {
     <>
       <Header />
 
-      <div className={classNames('reservation-detail-page')}>
+      <div className={classNames('reservation-detail-page', { 'fadein': fadeIn })}>
         <div className={classNames('title')}>
           <div className={classNames('text')}>마이페이지 {'>'} 예약 내역</div>
           <div className={classNames('reservation-info')}>

--- a/client/src/pages/ReservationDetail.js
+++ b/client/src/pages/ReservationDetail.js
@@ -20,7 +20,6 @@ export default function ReservationDetail() {
   }, []);
 
   useEffect(() => {
-    console.log('location: ', location);
     if (location.state && location.state.reservationId) {
       setReservationId(location.state.reservationId);
     }
@@ -31,7 +30,6 @@ export default function ReservationDetail() {
       axios
         .get(`/v1/reservation/${reservationId}/detail`)
         .then(response => {
-          console.log('response: ', response.data.data);
           setReservationDetail(response.data.data);
         })
         .catch(error => console.log(error));

--- a/client/src/styles/pages/reservationDetail.scss
+++ b/client/src/styles/pages/reservationDetail.scss
@@ -338,7 +338,7 @@
               width: 346px;
               height: 160px;
 
-              background: url(../../assets/image-7.png), lightgray 50% / cover no-repeat;
+              background: lightgray 50% / cover no-repeat;
             }
           }
         }

--- a/client/src/styles/pages/reservationDetail.scss
+++ b/client/src/styles/pages/reservationDetail.scss
@@ -810,6 +810,11 @@
           .image-wrapper {
             // 추가
             overflow: hidden;
+
+            .no-image {
+              color: $gray_200;
+              @extend %M_24;
+            }
           }
 
           .images {
@@ -905,6 +910,11 @@
           .image-wrapper {
             // 추가
             overflow: hidden;
+
+            .no-image {
+              color: $gray_200;
+              @extend %M_24;
+            }
           }
 
           .images {

--- a/client/src/styles/pages/reservationDetail.scss
+++ b/client/src/styles/pages/reservationDetail.scss
@@ -793,6 +793,18 @@
 
             transform: rotate(180deg);
             z-index: 99;
+
+            cursor: pointer;
+            transition: transform 0.3s ease-in-out;
+
+            &.disabled {
+              opacity: 0.2;
+              pointer-events: none;
+            }
+
+            &:hover {
+              transform: rotate(180deg) scale(1.3);
+            }
           }
 
           .image-wrapper {
@@ -819,6 +831,18 @@
 
             // 추가
             z-index: 99;
+
+            cursor: pointer;
+            transition: transform 0.3s ease-in-out;
+
+            &.disabled {
+              opacity: 0.2;
+              pointer-events: none;
+            }
+
+            &:hover {
+              transform: scale(1.3);
+            }
           }
         }
       }
@@ -864,6 +888,18 @@
 
             transform: rotate(180deg);
             z-index: 99;
+
+            cursor: pointer;
+            transition: transform 0.3s ease-in-out;
+
+            &.disabled {
+              opacity: 0.2;
+              pointer-events: none;
+            }
+
+            &:hover {
+              transform: rotate(180deg) scale(1.3);
+            }
           }
 
           .image-wrapper {
@@ -890,6 +926,18 @@
 
             // 추가
             z-index: 99;
+
+            cursor: pointer;
+            transition: transform 0.3s ease-in-out;
+
+            &.disabled {
+              opacity: 0.2;
+              pointer-events: none;
+            }
+
+            &:hover {
+              transform: scale(1.3);
+            }
           }
         }
       }

--- a/client/src/styles/pages/reservationDetail.scss
+++ b/client/src/styles/pages/reservationDetail.scss
@@ -645,6 +645,18 @@
 
               position: relative;
 
+              animation: breathe 1s infinite ease-in-out alternate;
+              transform-origin: center top;
+
+              @keyframes breathe {
+                0% {
+                  transform: scale(1);
+                }
+                100% {
+                  transform: scale(1.08);
+                }
+              }
+
               .ellipse-2 {
                 width: 60px;
                 height: 60px;

--- a/client/src/styles/pages/reservationDetail.scss
+++ b/client/src/styles/pages/reservationDetail.scss
@@ -51,7 +51,7 @@
 
   .body {
     display: flex;
-    padding: 0px 100px;
+    padding: 0px 200px;
     flex-direction: column;
     justify-content: center;
     align-items: flex-start;

--- a/client/src/styles/pages/reservationDetail.scss
+++ b/client/src/styles/pages/reservationDetail.scss
@@ -10,6 +10,13 @@
   top: 74px;
   margin-bottom: 74px;
 
+  opacity: 0; /* 페이지가 처음 로딩될 때 숨깁니다. */
+  transition: opacity 1.5s ease-in-out; /* 페이드 인 효과를 추가합니다. */
+
+  &.fadein {
+    opacity: 1; /* 페이지가 페이드 인될 때 보이게 합니다. */
+  }
+
   .title {
     display: flex;
     padding: 28px 100px 4px 100px;

--- a/client/src/styles/pages/reservationDetail.scss
+++ b/client/src/styles/pages/reservationDetail.scss
@@ -783,6 +783,8 @@
           gap: 30px;
           align-self: stretch;
 
+          justify-content: space-between;
+
           .arrow-left {
             display: flex;
             padding: 4px;
@@ -851,6 +853,8 @@
           align-items: center;
           gap: 30px;
           align-self: stretch;
+
+          justify-content: space-between;
 
           .arrow-left {
             display: flex;


### PR DESCRIPTION
## 📎 PR 제목
예약 상세 페이지에 애니메이션을 추가한다.

## 📎 작업 내용
- 불필요한 로그 제거

- 페이지 페이드인

- 이미지 캐러셀
  - 인덱스의 끝에 도달 시 버튼 비활성화
  - 호버 시 버튼 확대
  - 이미지 없는 경우 문구 출력 및 레이아웃 고정

- 현재 진행 단계 아이콘 breathe 적용

- 바디 가로 패딩 200px

- api 연동하여 차량 대표 이미지 출력
