### PR TITLE
[#177] 예약내역 리스트 출발일 기준 정렬

### DIFF
--- a/server/src/main/java/com/genesisairport/reservation/respository/ReservationRepository.java
+++ b/server/src/main/java/com/genesisairport/reservation/respository/ReservationRepository.java
@@ -15,5 +15,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     Reservation findReservationById(long reservationId);
 
+    @Query("SELECT r FROM Reservation r WHERE r.customer.id = :customerId  ORDER BY r.departureTime")
     List<Reservation> findReservationsByCustomerId(Long customerId);
 }

--- a/server/src/main/java/com/genesisairport/reservation/service/ReservationService.java
+++ b/server/src/main/java/com/genesisairport/reservation/service/ReservationService.java
@@ -108,7 +108,13 @@ public class ReservationService {
             Optional<CarImage> carImageOptional = carImageRepository.findBySellName(r.getSellName());
             if (carImageOptional.isPresent()) {
                 CarImage carImage = carImageOptional.get();
-                ReservationResponse.ReservationInfoAbstract reservationDTO = new ReservationResponse.ReservationInfoAbstract(r.getId(), r.getDepartureTime().toString(), r.getArrivalTime().toString(), r.getProgressStage(), r.getSellName(), r.getRepairShop().getShopName(), carImage.getImageUrl());
+
+                // LocalDateTime 포메팅
+                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+                String departureDate = r.getDepartureTime().format(formatter);
+                String arrivalDate = r.getArrivalTime().format(formatter);
+
+                ReservationResponse.ReservationInfoAbstract reservationDTO = new ReservationResponse.ReservationInfoAbstract(r.getId(), departureDate, arrivalDate, r.getProgressStage(), r.getSellName(), r.getRepairShop().getShopName(), carImage.getImageUrl());
                 reservationDTOs.add(reservationDTO);
             }
         }


### PR DESCRIPTION
## 📎 PR 제목
예약 목록을 `출발일` 기준으로 오름차순 정렬

## 📎 작업 내용
- findReservationsByCustomerId()에 출발일 기준 오름차순 정렬하도록 쿼리를 부착
- LocalDateTime 포메팅 -> yyyy-MM-dd

## 📎 필요한 후속 작업 
- 종료되거나 기간이 지난 예약에 대한 처리
