### PR TITLE
[#189] 예약 내역 리스트 정렬 기준 변경

### DIFF
--- a/server/src/main/java/com/genesisairport/reservation/respository/ReservationRepository.java
+++ b/server/src/main/java/com/genesisairport/reservation/respository/ReservationRepository.java
@@ -15,6 +15,8 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     Reservation findReservationById(long reservationId);
 
-    @Query("SELECT r FROM Reservation r WHERE r.customer.id = :customerId  ORDER BY r.departureTime")
+    @Query("SELECT r FROM Reservation r" +
+            " WHERE r.customer.id = :customerId " +
+            "ORDER BY r.progressStage desc, r.departureTime")
     List<Reservation> findReservationsByCustomerId(Long customerId);
 }

--- a/server/src/main/java/com/genesisairport/reservation/service/AuthService.java
+++ b/server/src/main/java/com/genesisairport/reservation/service/AuthService.java
@@ -74,7 +74,6 @@ public class AuthService {
 
         ResponseEntity<String> response = restTemplate.exchange(
                 tokenEndpoint, HttpMethod.GET, request, String.class); // GET 요청을 위해 exchange 메소드 사용
-        log.info(response.getBody());
 
         String email = extractStringValue(response.getBody(), "email");
 


### PR DESCRIPTION
## 📎 PR 제목

예약 내역 리스트 정렬 기준 변경

## 📎 작업 내용

- 예약 내역 리스트 조회 시 정렬 기준 변경
   - 기존 : 출발일 기준 정렬
   - 변경 : 1차 정렬은 진행 단계로 구분, 2차 정렬을 출발일 기준으로

- 로그 출력 코드 삭제

## 📎 후속 작업

- 지금은 진행 단계가 '예약중', '예약완료' 두 단계라서 String 정렬로 처리했는데, 단계가 세분화 되면 Enum 등으로 변경 필요합니다.