### PR TITLE
[#195] 로그아웃 후에도 로그인 상태의 헤더가 출력되는 문제 해결

### DIFF
--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -51,7 +51,7 @@ export default function Header() {
   const handleLogoutClick = async () => {
     try {
       const response = await axios.post('/v1/logout');
-      
+      window.location.reload();
     } catch (error) {
       console.error('Error calling logout API:', error);
     }


### PR DESCRIPTION
## 📎 PR 제목
로그아웃 후에도 로그인 상태의 헤더가 출력되는 문제 해결

## 📎 작업 내용
- 로그인 버튼 클릭 시 페이지 새로고침하여 비로그인 상태의 헤더를 출력함
