### PR TITLE
[#200] 쿠키 생성 안 되는 문제 해결

### DIFF
--- a/client/src/api/Settings.js
+++ b/client/src/api/Settings.js
@@ -1,7 +1,11 @@
 import Axios from 'axios';
 
 const axios = Axios.create({
-  baseURL: 'http://api.reservation.genesis-airport.com/',
+  baseURL: `${process.env.REACT_APP_SERVER_URL}`,
+  withCredentials: true,
+  headers: {
+    'Access-Control-Allow-Origin': `${process.env.REACT_APP_SERVER_URL}`,
+  }
 });
 
 export default axios;

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -1,9 +1,8 @@
 import { Link } from 'react-router-dom';
 import classNames from 'classnames';
 import logo_header from '../assets/logo-header.png';
-import Cookies from 'js-cookie';
 import { useEffect, useState } from 'react';
-import axios from 'axios';
+import axios from '../api/Settings';
 
 export default function Header() {
   const [isLogin, setIsLogin] = useState(false);
@@ -11,14 +10,32 @@ export default function Header() {
   const clientId = process.env.REACT_APP_CLIENT_ID;
   const host = process.env.REACT_APP_REDIRECT_URI;
 
+  const checkSession = async () => {
+    try {
+      const response = await axios.get('/v1/login');
+      const responseData = response.data;
+      
+      if (responseData && responseData.success) {
+        setIsLogin(true); 
+      } else {
+        setIsLogin(false); 
+      }
+    } catch (error) {
+      console.error('Error checking session:', error);
+      setIsLogin(false);
+    }
+  };
+
+  
   // RFC4122 version 4 UUID
   useEffect(() => {
     setUuid(createUUID());
 
-    const sid = Cookies.get('SID');
-    if (sid) {
-      setIsLogin(true);
-    }
+    // const sid = Cookies.get('SID');
+    // if (sid) {
+    //   setIsLogin(true);
+    // }
+    checkSession();
 
     const header = document.querySelector('.header');
     const page = document.querySelector('#root').querySelector('div');

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -31,10 +31,6 @@ export default function Header() {
   useEffect(() => {
     setUuid(createUUID());
 
-    // const sid = Cookies.get('SID');
-    // if (sid) {
-    //   setIsLogin(true);
-    // }
     checkSession();
 
     const header = document.querySelector('.header');

--- a/server/src/main/java/com/genesisairport/reservation/config/WebConfig.java
+++ b/server/src/main/java/com/genesisairport/reservation/config/WebConfig.java
@@ -13,7 +13,7 @@ public class WebConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry
                 .addMapping("/**")
-                .allowedOrigins("http://localhost:3000", "reservation.genesis-airport.com")
+                .allowedOrigins("http://localhost:3000", "http://reservation.genesis-airport.com")
                 .allowedMethods("*")
                 .allowCredentials(true);
     }

--- a/server/src/main/java/com/genesisairport/reservation/config/WebConfig.java
+++ b/server/src/main/java/com/genesisairport/reservation/config/WebConfig.java
@@ -1,0 +1,21 @@
+package com.genesisairport.reservation.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@EnableWebMvc
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry
+                .addMapping("/**")
+                .allowedOrigins("http://localhost:3000", "reservation.genesis-airport.com")
+                .allowedMethods("*")
+                .allowCredentials(true);
+    }
+
+}

--- a/server/src/main/java/com/genesisairport/reservation/controller/AuthController.java
+++ b/server/src/main/java/com/genesisairport/reservation/controller/AuthController.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@CrossOrigin
 @Slf4j
 @RequestMapping("/v1")
 public class AuthController {
@@ -35,6 +34,23 @@ public class AuthController {
 
         return new ResponseEntity(
                 ResponseDto.of(true, ResponseCode.OK),
+                HttpStatus.OK
+        );
+    }
+
+    @GetMapping("/login")
+    public ResponseEntity isLoggedIn(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+
+        if (session != null && session.getAttribute("userId") != null) {
+            return new ResponseEntity(
+                    ResponseDto.of(true, ResponseCode.OK),
+                    HttpStatus.OK
+            );
+        }
+
+        return new ResponseEntity<>(
+                ResponseDto.of(false, ResponseCode.UNAUTHORIZED),
                 HttpStatus.OK
         );
     }

--- a/server/src/main/java/com/genesisairport/reservation/controller/AuthController.java
+++ b/server/src/main/java/com/genesisairport/reservation/controller/AuthController.java
@@ -25,6 +25,14 @@ public class AuthController {
     public ResponseEntity login(@RequestBody UserRequest.Login login, HttpServletRequest request) {
         // OAuth 토큰 발급
         String accessToken = authService.tokenRequest(login);
+
+        if (accessToken.isEmpty() || accessToken.isBlank()) {
+            return new ResponseEntity<>(
+                    ResponseDto.of(false, ResponseCode.BAD_REQUEST),
+                    HttpStatus.OK
+            );
+        }
+
         // 사용자 정보 조회 및 저장
         long userId = authService.userProfileRequest(accessToken);
         // 세션 생성

--- a/server/src/main/java/com/genesisairport/reservation/controller/CarController.java
+++ b/server/src/main/java/com/genesisairport/reservation/controller/CarController.java
@@ -17,7 +17,6 @@ import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
-@CrossOrigin
 @Slf4j
 @RequestMapping("/v2/car")
 public class CarController {

--- a/server/src/main/java/com/genesisairport/reservation/controller/ReservationController.java
+++ b/server/src/main/java/com/genesisairport/reservation/controller/ReservationController.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
-@CrossOrigin
 @Slf4j
 @RequestMapping("/v1/reservation")
 public class ReservationController {

--- a/server/src/main/java/com/genesisairport/reservation/controller/TextController.java
+++ b/server/src/main/java/com/genesisairport/reservation/controller/TextController.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
-@CrossOrigin
 public class TextController {
 
     @GetMapping("/")

--- a/server/src/main/java/com/genesisairport/reservation/controller/UserController.java
+++ b/server/src/main/java/com/genesisairport/reservation/controller/UserController.java
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 @Controller
-@CrossOrigin
 @RequestMapping("/v1/user")
 @RequiredArgsConstructor
 public class UserController {

--- a/server/src/main/java/com/genesisairport/reservation/service/AuthService.java
+++ b/server/src/main/java/com/genesisairport/reservation/service/AuthService.java
@@ -46,12 +46,7 @@ public class AuthService {
         String parameters = getParameters(requestBody);
         HttpEntity<String> request = new HttpEntity<>(parameters, headers); // 요청 헤더와 바디 설정
 
-        System.out.println("request body = " + requestBody.getRedirectUri());
-        System.out.println("request = " + request.getBody());
-
         ResponseEntity<String> response = restTemplate.postForEntity(tokenEndpoint, request, String.class); // POST 요청
-
-        System.out.println("response = " + response.getBody());
 
         return extractStringValue(response.getBody(), "access_token");
     }
@@ -77,8 +72,6 @@ public class AuthService {
 
         headers.add("Authorization", "Bearer " + accessToken); // Authorization 헤더에 Access Token 추가
         HttpEntity<String> request = new HttpEntity<>(headers); // HttpEntity에 헤더만 포함시킴
-
-        System.out.println("access token : " + accessToken);
 
         ResponseEntity<String> response = restTemplate.exchange(
                 tokenEndpoint, HttpMethod.GET, request, String.class); // GET 요청을 위해 exchange 메소드 사용

--- a/server/src/main/java/com/genesisairport/reservation/service/AuthService.java
+++ b/server/src/main/java/com/genesisairport/reservation/service/AuthService.java
@@ -45,7 +45,13 @@ public class AuthService {
 
         String parameters = getParameters(requestBody);
         HttpEntity<String> request = new HttpEntity<>(parameters, headers); // 요청 헤더와 바디 설정
+
+        System.out.println("request body = " + requestBody.getRedirectUri());
+        System.out.println("request = " + request.getBody());
+
         ResponseEntity<String> response = restTemplate.postForEntity(tokenEndpoint, request, String.class); // POST 요청
+
+        System.out.println("response = " + response.getBody());
 
         return extractStringValue(response.getBody(), "access_token");
     }
@@ -71,6 +77,8 @@ public class AuthService {
 
         headers.add("Authorization", "Bearer " + accessToken); // Authorization 헤더에 Access Token 추가
         HttpEntity<String> request = new HttpEntity<>(headers); // HttpEntity에 헤더만 포함시킴
+
+        System.out.println("access token : " + accessToken);
 
         ResponseEntity<String> response = restTemplate.exchange(
                 tokenEndpoint, HttpMethod.GET, request, String.class); // GET 요청을 위해 exchange 메소드 사용

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -34,5 +34,5 @@ server:
         name: SID
         domain:
         path: /
-        http-only: false
+        http-only: true
         secure: false


### PR DESCRIPTION
## 📎 PR 제목

쿠키 생성 안 되는 문제 해결

## 📎 작업 내용

- WebConfig 파일 생성
   - withCredentials 허용
   - 컨트롤러에 있는 @CrossOrigin 삭제

- HttpOnly 설정 변경
   - false -> true로 변경
   - 이제 js에서 쿠키 접근 불가

- 로그인 된 상태인지 확인하는 API 추가
   - GET `/v1/login`

- 로그인 API 예외처리
   - 기존 : OAuth 요청 실패 시 500 에러 발생 -> 프론트에서 리다이렉트 페이지에서 머무는 문제 발생
   - 변경 : OAuth 요청 실패 시에도 200 response 반환, body 값을 다르게 설정 -> 로그인 실패 시에도 메인으로 리다이렉트

## 📎 변경 로직

### 헤더의 상태 바꾸는 로직

기존에는 쿠키 값의 존재 여부에 따라 헤더의 상태가 달라지는 방식이었습니다.

쿠키가 존재한다면 '로그아웃' 버튼이 있는 헤더를, 쿠키가 없다면 '로그인 '버튼이 있는 헤더를 표시해주었습니다.

그러나 HttpOnly의 값을 false에서 true로 바꾸면서, js에서 쿠키에 접근하지 못 하는 이슈가 발생했고 그에 따라 기존 코드를 사용하지 못 하게 되었습니다.

그래서 로그인 여부를 판단하는 API를 하나 만들어, 서버에 로그인 여부를 판단하는 API를 전송하고, 그 반환값에 따라 헤더의 상태를 결정하는 로직으로 변경했습니다.

## 📎 필요한 후속 작업 

- HTTPS 적용 후, Secure 설정 값 true로 바꾸기

- 세션을 적용할 도메인 지정하기 (현재: 지정X)
  1. application.yml 프로필 분리하기
  2. 개발이 끝난 후 한 번에 적용하기

