### PR TITLE
[#208] 진행 단계 추가 api

### DIFF
--- a/server/src/main/java/com/genesisairport/reservation/common/ProgressStage.java
+++ b/server/src/main/java/com/genesisairport/reservation/common/ProgressStage.java
@@ -1,0 +1,27 @@
+package com.genesisairport.reservation.common;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProgressStage {
+    RESERVATION_APPROVED("예약완료"),
+    TO_GARAGE("차량인수"),
+    MAINTENANCE("정비중"),
+    PARKING("보관중"),
+    TO_CUSTOMER("차량인계");
+
+    private final String name;
+
+    @JsonCreator
+    public static ProgressStage of(String progress) {
+        return Arrays.stream(ProgressStage.values())
+                .filter(i -> i.name.equals(progress))
+                .findAny()
+                .orElse(null);
+    }
+}

--- a/server/src/main/java/com/genesisairport/reservation/controller/AdminController.java
+++ b/server/src/main/java/com/genesisairport/reservation/controller/AdminController.java
@@ -1,0 +1,30 @@
+package com.genesisairport.reservation.controller;
+
+import com.genesisairport.reservation.common.ResponseCode;
+import com.genesisairport.reservation.common.ResponseDto;
+import com.genesisairport.reservation.request.AdminRequest;
+import com.genesisairport.reservation.service.AdminService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/v2/admin")
+public class AdminController {
+
+    private final AdminService adminService;
+
+    @PostMapping("/reservation/progress")
+    public ResponseEntity registerStage(
+            @RequestBody AdminRequest.StageInfo requestBody) {
+        log.debug("관리자 | 진행 단계 추가");
+
+        adminService.saveStage(requestBody);
+        return new ResponseEntity<>(ResponseDto.of(true, ResponseCode.OK), HttpStatus.OK);
+    }
+
+}

--- a/server/src/main/java/com/genesisairport/reservation/controller/AdminController.java
+++ b/server/src/main/java/com/genesisairport/reservation/controller/AdminController.java
@@ -23,6 +23,10 @@ public class AdminController {
             @RequestBody AdminRequest.StageInfo requestBody) {
         log.debug("관리자 | 진행 단계 추가");
 
+        if (requestBody.getProgress() == null) {
+            return new ResponseEntity<>(ResponseDto.of(false, ResponseCode.INTERNAL_ERROR), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
         adminService.saveStage(requestBody);
         return new ResponseEntity<>(ResponseDto.of(true, ResponseCode.OK), HttpStatus.OK);
     }

--- a/server/src/main/java/com/genesisairport/reservation/controller/AdminController.java
+++ b/server/src/main/java/com/genesisairport/reservation/controller/AdminController.java
@@ -1,5 +1,6 @@
 package com.genesisairport.reservation.controller;
 
+import com.genesisairport.reservation.common.GeneralException;
 import com.genesisairport.reservation.common.ResponseCode;
 import com.genesisairport.reservation.common.ResponseDto;
 import com.genesisairport.reservation.request.AdminRequest;
@@ -24,7 +25,7 @@ public class AdminController {
         log.debug("관리자 | 진행 단계 추가");
 
         if (requestBody.getProgress() == null) {
-            return new ResponseEntity<>(ResponseDto.of(false, ResponseCode.INTERNAL_ERROR), HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new GeneralException(ResponseCode.INTERNAL_ERROR, "유효하지 않은 진행단계입니다.");
         }
 
         adminService.saveStage(requestBody);

--- a/server/src/main/java/com/genesisairport/reservation/request/AdminRequest.java
+++ b/server/src/main/java/com/genesisairport/reservation/request/AdminRequest.java
@@ -1,0 +1,20 @@
+package com.genesisairport.reservation.request;
+
+import com.genesisairport.reservation.common.ProgressStage;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class AdminRequest {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class StageInfo {
+        private Long reservationId;
+        private ProgressStage progress;
+        private String detail;
+    }
+}

--- a/server/src/main/java/com/genesisairport/reservation/service/AdminService.java
+++ b/server/src/main/java/com/genesisairport/reservation/service/AdminService.java
@@ -1,0 +1,32 @@
+package com.genesisairport.reservation.service;
+
+import com.genesisairport.reservation.entity.Step;
+import com.genesisairport.reservation.request.AdminRequest;
+import com.genesisairport.reservation.respository.ReservationRepository;
+import com.genesisairport.reservation.respository.StepRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AdminService {
+
+    private final ReservationRepository reservationRepository;
+    private final StepRepository stepRepository;
+
+    public void saveStage(AdminRequest.StageInfo requestBody) {
+        Step newStep = Step.builder()
+                .stage(requestBody.getProgress().getName())
+                .date(LocalDateTime.now())
+                .detail(requestBody.getDetail())
+                .createDatetime(LocalDateTime.now())
+                .updateDatetime(LocalDateTime.now())
+                .reservation(reservationRepository.findReservationById(requestBody.getReservationId()))
+                .build();
+        stepRepository.save(newStep);
+    }
+}

--- a/server/src/main/java/com/genesisairport/reservation/service/ReservationService.java
+++ b/server/src/main/java/com/genesisairport/reservation/service/ReservationService.java
@@ -1,5 +1,6 @@
 package com.genesisairport.reservation.service;
 
+import com.genesisairport.reservation.common.ProgressStage;
 import com.genesisairport.reservation.entity.*;
 import com.genesisairport.reservation.request.ReservationRequest;
 import com.genesisairport.reservation.response.ReservationResponse;
@@ -95,7 +96,7 @@ public class ReservationService {
                 // 초기 진행 단계 설정
                 Step step = Step.builder()
                         .reservation(reservation)
-                        .stage("예약완료")
+                        .stage(ProgressStage.RESERVATION_APPROVED.getName())
                         .date(LocalDateTime.now())
                         .detail("")
                         .createDatetime(LocalDateTime.now())


### PR DESCRIPTION
## ✨ 작업 내용
1. 진행 단계 enum 생성
2. 진행 단계 추가 api 개발
3. Invalid enum 예외처리

## 📎 상세 설명 (스크린샷 포함 가능)
1. 진행 단계 enum 생성

5단계로 구성된 `ProgressStage` ENUM을 생성합니다.

```java
RESERVATION_APPROVED("예약완료"),
TO_GARAGE("차량인수"),
MAINTENANCE("정비중"),
PARKING("보관중"),
TO_CUSTOMER("차량인계");
```

2. 진행 단계 추가 api 개발

```java
@PostMapping("/reservation/progress")
public ResponseEntity registerStage(
        @RequestBody AdminRequest.StageInfo requestBody) {
    log.debug("관리자 | 진행 단계 추가");

    if (requestBody.getProgress() == null) {
        throw new GeneralException(ResponseCode.INTERNAL_ERROR, "유효하지 않은 진행단계입니다.");
    }

    adminService.saveStage(requestBody);
    return new ResponseEntity<>(ResponseDto.of(true, ResponseCode.OK), HttpStatus.OK);
}
```

3. Invalid enum 예외처리

`@RequestBody`로 enum 요청을 받으려면 숫자로 입력받아야합니다. 이는 관리에 유리하지 않다고 판단하여 `@JsonCreator`를 사용하여 enum의 name 값으로 enum을 입력 받도록 구현했습니다.

```java
@JsonCreator
public static ProgressStage of(String progress) {
    return Arrays.stream(ProgressStage.values())
            .filter(i -> i.name.equals(progress))
            .findAny()
            .orElse(null);
}
```

요청으로 들어온 enum 값이 유효하지 않은 경우 `requestBody`에 null이 저장됩니다. 이 상황의 예외를 처리하기 위해 이슈 #205에서 정의한 GlobalException를 사용했습니다.

```java
if (requestBody.getProgress() == null) {
    throw new GeneralException(ResponseCode.INTERNAL_ERROR, "유효하지 않은 진행단계입니다.");
}
```

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

- `@JsonCreator`

> `@RequestBody`로 enum 요청 데이터를 받는 경우, 유효성을 검증하여 값을 입력받기 위해 다음 코드를 사용할 수 있습니다.
 
```java
@JsonCreator
public static ProgressStage of(String progress) {
    return Arrays.stream(ProgressStage.values())
            .filter(i -> i.name.equals(progress))
            .findAny()
            .orElse(null);
}
```
