### PR TITLE
[#207] 세션 인터셉터 추가

### DIFF
--- a/client/src/api/Settings.js
+++ b/client/src/api/Settings.js
@@ -8,5 +8,18 @@ const axios = Axios.create({
   }
 });
 
+axios.interceptors.response.use(
+  response => {
+    // 200 OK
+    return response;
+  },
+  error => {
+    if (error.response.status === 401) {
+      window.location.href = '/';
+    }
+    return Promise.reject(error);
+  }
+);
+
 export default axios;
 /* github actions test */

--- a/server/src/main/java/com/genesisairport/reservation/common/RedisUtil.java
+++ b/server/src/main/java/com/genesisairport/reservation/common/RedisUtil.java
@@ -8,19 +8,19 @@ import java.time.Duration;
 
 @Component
 public class RedisUtil {
-    private final RedisTemplate<String, String> redisTemplate;
+    private final RedisTemplate<String, Object> redisTemplate;
 
-    public RedisUtil(RedisTemplate<String, String> redisTemplate) {
+    public RedisUtil(RedisTemplate<String, Object> redisTemplate) {
         this.redisTemplate = redisTemplate;
     }
 
-    public void setValues(String key, String data) {
-        ValueOperations<String, String> values = redisTemplate.opsForValue();
+    public void setValues(String key, Object data) {
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
         values.set(key, data, Duration.ofHours(1));
     }
 
-    public String getValues(String key) {
-        ValueOperations<String, String> values = redisTemplate.opsForValue();
+    public Object getValues(String key) {
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
         return values.get(key);
     }
 

--- a/server/src/main/java/com/genesisairport/reservation/common/SessionInterceptor.java
+++ b/server/src/main/java/com/genesisairport/reservation/common/SessionInterceptor.java
@@ -1,0 +1,44 @@
+package com.genesisairport.reservation.common;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@RequiredArgsConstructor
+public class SessionInterceptor implements HandlerInterceptor {
+
+    private static final String SESSION_PREFIX = "spring:session:sessions:";
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        HttpSession session = request.getSession(false);
+
+        if (session == null) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return false;
+        }
+
+        String sessionKey = getSessionKey(session.getId());
+
+        if (!isSessionExists(sessionKey)) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return false;
+        }
+
+        return true;
+    }
+
+    private String getSessionKey(String sessionId) {
+        return SESSION_PREFIX + sessionId;
+    }
+
+    private Boolean isSessionExists(String sessionKey) {
+        return redisTemplate.hasKey(sessionKey);
+    }
+}

--- a/server/src/main/java/com/genesisairport/reservation/config/WebConfig.java
+++ b/server/src/main/java/com/genesisairport/reservation/config/WebConfig.java
@@ -13,27 +13,28 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 
 @Configuration
-@Order(Ordered.HIGHEST_PRECEDENCE)
 public class WebConfig implements WebMvcConfigurer {
 
     @Autowired
     private RedisTemplate<String, Object> redisTemplate;
 
     @Override
+    @Order(Ordered.HIGHEST_PRECEDENCE)
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedOrigins("http://localhost:3000", "http://reservation.genesis-airport.com")
                 .allowedMethods("*")
                 .allowedHeaders("*")
                 .allowCredentials(true)
-                .maxAge(3600);
+                .maxAge(86400);
     }
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new SessionInterceptor(redisTemplate))
-                .order(1)
-                .addPathPatterns("/v1/**") //TODO v2 api 완성되면 추가
-                .excludePathPatterns("/v1/login", "/");
+                .order(2)
+                .addPathPatterns("/**")
+                .excludePathPatterns("/v1/login", "/"); //TODO v2 api 완성되면 추가
     }
+
 }

--- a/server/src/main/java/com/genesisairport/reservation/config/WebConfig.java
+++ b/server/src/main/java/com/genesisairport/reservation/config/WebConfig.java
@@ -1,16 +1,23 @@
 package com.genesisairport.reservation.config;
 
 
+import com.genesisairport.reservation.common.SessionInterceptor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 
 @Configuration
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class WebConfig implements WebMvcConfigurer {
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -22,4 +29,11 @@ public class WebConfig implements WebMvcConfigurer {
                 .maxAge(3600);
     }
 
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new SessionInterceptor(redisTemplate))
+                .order(1)
+                .addPathPatterns("/v1/**") //TODO v2 api 완성되면 추가
+                .excludePathPatterns("/v1/login", "/");
+    }
 }


### PR DESCRIPTION
## ✨ 작업 내용

- `SessionInterceptor` 클래스 생성

- `WebConfig` 클래스에 메소드 추가

- Axios interceptor 추가

## 📎 상세 설명 (스크린샷 포함 가능)

### SessionInterceptor 클래스 생성

Session이 없거나 주어진 세션이 유효하지 않은 세션일 때, 서버에서 401 Response를 반환함.

세션 검증을 통과하면 request를 controller로 전달함. 

### WebConfig 클래스에 메소드 추가

`WebConfig` 클래스에 인터셉터를 등록하는 **addInterceptors()** 메소드 추가.

해당 메소드에서 `SessionInterceptor` 클래스 등록해서 특정 URI에 대해 해당 인터셉터가 실행되도록 함.

### Axios Interceptor 추가

```js
axios.interceptors.response.use(
  response => {
    // 200 OK
    return response;
  },
  error => {
    if (error.response.status === 401) {
      window.location.href = '/';
    }
    return Promise.reject(error);
  }
);
```

`setting.js` 파일에 Axios 인터셉터 코드 추가함.

서버의 response가 401이면, 메인 페이지로 리다이렉트 되도록 함.

## 📎 필요한 후속 작업

- 혹시 CORS 에러가 난다면 `WebConfig` 클래스랑 `SessionInterceptor` 클래스 수정하기

- 시간이 난다면, 401 응답으로 메인 페이지로 리다이렉트 되기 전 이전 페이지 뜨는 현상 수정하기


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

### axios.interceptors.response.use() 에 대해

`axios.interceptors.response.use()` 함수는 Axios에서 응답을 가로채고 처리하는 인터셉터로, `then` 또는 `catch` 로 처리되기 전에 요청과 응답을 가로챌수 있다.

이 함수는 다음과 같은 형식을 가진다.

```js
// 요청 인터셉터 추가하기
axios.interceptors.request.use(function (config) {
    // 요청이 전달되기 전에 작업 수행
    return config;
  }, function (error) {
    // 요청 오류가 있는 작업 수행
    return Promise.reject(error);
  });

// 응답 인터셉터 추가하기
axios.interceptors.response.use(function (response) {
    // 2xx 범위에 있는 상태 코드는 이 함수를 트리거 합니다.
    // 응답 데이터가 있는 작업 수행
    return response;
  }, function (error) {
    // 2xx 외의 범위에 있는 상태 코드는 이 함수를 트리거 합니다.
    // 응답 오류가 있는 작업 수행
    return Promise.reject(error);
  });
```

그리고 두 개의 콜백 함수를 파라미터로 받는데, 이는 다음과 같다. 

1. 첫 번째 콜백 함수

- 성공한 응답을 처리하는 로직
- 서버로부터 2xx response를 받았을 때 실행되고, response 객체를 파라미터로 받는다.
- response를 원하는 형태로 변환할 수 있는데, 이렇게 반환된 response 객체는 이후의 `then` 핸들러로 전달된다.

2. 두 번째 콜백 함수

- 실패한 응답을 처리하는 로직
- 서버로부터 실패한 응답을 받았을 대 실행되고, error 객체를 파라미터로 받는다.
- response를 원하는 형태로 변환할 수 있는데, response 객체는 이후의 `catch` 핸들러로 전달된다.

#### 참고) 인터셉터 제거와 추가

##### 인터셉터 제거하기

```js
const myInterceptor = axios.interceptors.request.use(function () {/*...*/});
axios.interceptors.request.eject(myInterceptor);
```

##### 인터셉터 추가하기

```js
const instance = axios.create();
instance.interceptors.request.use(function () {/*...*/});
```

참고
https://axios-http.com/kr/docs/interceptors
