### PR TITLE
[#215] 예약 단계 삭제 api

### DIFF
--- a/server/src/main/java/com/genesisairport/reservation/common/ProgressStage.java
+++ b/server/src/main/java/com/genesisairport/reservation/common/ProgressStage.java
@@ -24,4 +24,13 @@ public enum ProgressStage {
                 .findAny()
                 .orElse(null);
     }
+
+    public static ProgressStage fromName(String name) {
+        for (ProgressStage stage : ProgressStage.values()) {
+            if (stage.name.equals(name)) {
+                return stage;
+            }
+        }
+        throw new IllegalArgumentException("Invalid stage name: " + name);
+    }
 }

--- a/server/src/main/java/com/genesisairport/reservation/common/ProgressStage.java
+++ b/server/src/main/java/com/genesisairport/reservation/common/ProgressStage.java
@@ -31,6 +31,6 @@ public enum ProgressStage {
                 return stage;
             }
         }
-        throw new IllegalArgumentException("Invalid stage name: " + name);
+        throw new GeneralException(ResponseCode.INTERNAL_ERROR, "유효하지 않은 stage name 입니다. : " + name);
     }
 }

--- a/server/src/main/java/com/genesisairport/reservation/controller/admin/AdminReservationController.java
+++ b/server/src/main/java/com/genesisairport/reservation/controller/admin/AdminReservationController.java
@@ -32,4 +32,17 @@ public class AdminReservationController {
         return new ResponseEntity<>(ResponseDto.of(true, ResponseCode.OK), HttpStatus.OK);
     }
 
+    @DeleteMapping("/reservation/progress")
+    public ResponseEntity deleteStage(
+            @RequestBody AdminRequest.StageInfo requestBody) {
+        log.debug("관리자 | 진행 단계 삭제");
+
+        if (requestBody.getProgress() == null) {
+            throw new GeneralException(ResponseCode.INTERNAL_ERROR, "유효하지 않은 진행단계입니다.");
+        }
+
+        adminReservationService.deleteStage(requestBody);
+        return new ResponseEntity<>(ResponseDto.of(true, ResponseCode.OK), HttpStatus.OK);
+    }
+
 }

--- a/server/src/main/java/com/genesisairport/reservation/entity/Car.java
+++ b/server/src/main/java/com/genesisairport/reservation/entity/Car.java
@@ -10,7 +10,6 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-@Setter
 @Builder
 public class Car {
 

--- a/server/src/main/java/com/genesisairport/reservation/entity/CarImage.java
+++ b/server/src/main/java/com/genesisairport/reservation/entity/CarImage.java
@@ -8,7 +8,6 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@Setter
 @Table(name = "car_image")
 public class CarImage {
 

--- a/server/src/main/java/com/genesisairport/reservation/entity/Coupon.java
+++ b/server/src/main/java/com/genesisairport/reservation/entity/Coupon.java
@@ -12,7 +12,6 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 @Getter
-@Setter
 public class Coupon {
 
     @Id
@@ -26,6 +25,7 @@ public class Coupon {
     private LocalDate expiredDate;
 
     @Column(name = "is_used", nullable = false)
+    @Setter
     private Boolean isUsed;
 
     @Column(name = "create_datetime", nullable = false)

--- a/server/src/main/java/com/genesisairport/reservation/entity/Reservation.java
+++ b/server/src/main/java/com/genesisairport/reservation/entity/Reservation.java
@@ -13,7 +13,6 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 @Getter
-@Setter
 public class Reservation {
 
     @Id
@@ -42,6 +41,7 @@ public class Reservation {
     private String customerRequest;
 
     @Column(name = "progress_stage", nullable = false, length = 20)
+    @Setter
     private String progressStage;
 
     @Column(name = "inspection_result", length = 2000)

--- a/server/src/main/java/com/genesisairport/reservation/entity/Reservation.java
+++ b/server/src/main/java/com/genesisairport/reservation/entity/Reservation.java
@@ -1,10 +1,7 @@
 package com.genesisairport.reservation.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -16,6 +13,7 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 @Getter
+@Setter
 public class Reservation {
 
     @Id

--- a/server/src/main/java/com/genesisairport/reservation/entity/Step.java
+++ b/server/src/main/java/com/genesisairport/reservation/entity/Step.java
@@ -15,6 +15,7 @@ public class Step {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Getter
     private Long id;
 
     @Column(nullable = false, length = 20)

--- a/server/src/main/java/com/genesisairport/reservation/respository/StepRepository.java
+++ b/server/src/main/java/com/genesisairport/reservation/respository/StepRepository.java
@@ -2,6 +2,13 @@ package com.genesisairport.reservation.respository;
 
 import com.genesisairport.reservation.entity.Step;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface StepRepository extends JpaRepository<Step, Long> {
+
+    Step findStepByReservationIdAndStage(
+            @Param("reservationId") Long reservation,
+            @Param("stage") String progress);
 }

--- a/server/src/main/java/com/genesisairport/reservation/respository/StepRepository.java
+++ b/server/src/main/java/com/genesisairport/reservation/respository/StepRepository.java
@@ -2,8 +2,11 @@ package com.genesisairport.reservation.respository;
 
 import com.genesisairport.reservation.entity.Step;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface StepRepository extends JpaRepository<Step, Long> {
@@ -11,4 +14,7 @@ public interface StepRepository extends JpaRepository<Step, Long> {
     Step findStepByReservationIdAndStage(
             @Param("reservationId") Long reservation,
             @Param("stage") String progress);
+
+    @Query("SELECT s.stage FROM Step s WHERE s.reservation.id = :reservationId")
+    List<String> findStagesByReservationId(@Param("reservationId") Long reservationId);
 }

--- a/server/src/main/java/com/genesisairport/reservation/service/admin/AdminReservationService.java
+++ b/server/src/main/java/com/genesisairport/reservation/service/admin/AdminReservationService.java
@@ -9,6 +9,7 @@ import com.genesisairport.reservation.respository.StepRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
@@ -34,5 +35,15 @@ public class AdminReservationService {
         } catch (Exception e) {
             throw new GeneralException(ResponseCode.INTERNAL_ERROR, "이미 추가된 진행 단계입니다.");
         }
+    }
+
+    @Transactional
+    public void deleteStage(AdminRequest.StageInfo requestBody) {
+        Long stepId = stepRepository.findStepByReservationIdAndStage(
+                requestBody.getReservationId(),
+                requestBody.getProgress().getName()).getId();
+
+        stepRepository.deleteById(stepId);
+
     }
 }

--- a/server/src/main/java/com/genesisairport/reservation/service/admin/AdminReservationService.java
+++ b/server/src/main/java/com/genesisairport/reservation/service/admin/AdminReservationService.java
@@ -1,5 +1,7 @@
 package com.genesisairport.reservation.service.admin;
 
+import com.genesisairport.reservation.common.GeneralException;
+import com.genesisairport.reservation.common.ResponseCode;
 import com.genesisairport.reservation.entity.Step;
 import com.genesisairport.reservation.request.AdminRequest;
 import com.genesisairport.reservation.respository.ReservationRepository;
@@ -27,6 +29,10 @@ public class AdminReservationService {
                 .updateDatetime(LocalDateTime.now())
                 .reservation(reservationRepository.findReservationById(requestBody.getReservationId()))
                 .build();
-        stepRepository.save(newStep);
+        try {
+            stepRepository.save(newStep);
+        } catch (Exception e) {
+            throw new GeneralException(ResponseCode.INTERNAL_ERROR, "이미 추가된 진행 단계입니다.");
+        }
     }
 }

--- a/server/src/main/java/com/genesisairport/reservation/service/admin/AdminReservationService.java
+++ b/server/src/main/java/com/genesisairport/reservation/service/admin/AdminReservationService.java
@@ -1,7 +1,9 @@
 package com.genesisairport.reservation.service.admin;
 
 import com.genesisairport.reservation.common.GeneralException;
+import com.genesisairport.reservation.common.ProgressStage;
 import com.genesisairport.reservation.common.ResponseCode;
+import com.genesisairport.reservation.entity.Reservation;
 import com.genesisairport.reservation.entity.Step;
 import com.genesisairport.reservation.request.AdminRequest;
 import com.genesisairport.reservation.respository.ReservationRepository;
@@ -12,6 +14,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -35,6 +39,8 @@ public class AdminReservationService {
         } catch (Exception e) {
             throw new GeneralException(ResponseCode.INTERNAL_ERROR, "이미 추가된 진행 단계입니다.");
         }
+
+        setLatestStage(requestBody);
     }
 
     @Transactional
@@ -45,5 +51,23 @@ public class AdminReservationService {
 
         stepRepository.deleteById(stepId);
 
+        setLatestStage(requestBody);
+    }
+
+    private void setLatestStage(AdminRequest.StageInfo requestBody) {
+        // 예약 현황 갱신
+        Reservation reservation = reservationRepository.findReservationById(requestBody.getReservationId());
+
+        List<ProgressStage> stages = stepRepository.findStagesByReservationId(requestBody.getReservationId()).stream()
+                .map(ProgressStage::fromName)
+                .collect(Collectors.toList());
+
+        reservation.setProgressStage(stages.stream()
+                .max(Enum::compareTo)
+                .orElse(null)
+                .getName()
+        );
+
+        reservationRepository.save(reservation);
     }
 }


### PR DESCRIPTION
## ✨ 작업 내용
1. unique 제약조건 추가
2. 예약 진행 단계 삭제 api
3. 최상위 단계를 현재 단계로 저장하는 모듈 개발

## 📎 상세 설명 (스크린샷 포함 가능)
1. unique 제약조건을 추가
> 하나의 예약 id에 대해 동일한 예약 단계가 있으면 안된다고 판단하여 step 테이블의 reservation_id, stage에 unique 제약조건을 추가했습니다.

2. 예약 진행 단계 삭제 api
> 요청의 진행 단계에 해당하는 레코드를 삭제합니다.

```java
@Transactional
public void deleteStage(AdminRequest.StageInfo requestBody) {
    Long stepId = stepRepository.findStepByReservationIdAndStage(
            requestBody.getReservationId(),
            requestBody.getProgress().getName()).getId();

    stepRepository.deleteById(stepId);

    setLatestStage(requestBody);
}
```

3. 최상위 단계를 현재 단계로 저장하는 모듈 개발
> 진행 단계를 추가/삭제한 후 모듈을 실행하여, 진행 단계 중 최상위 단계를 현재 예약의 진행 단계로 지정합니다.

```java
private void setLatestStage(AdminRequest.StageInfo requestBody) {
    // 예약 현황 갱신
    Reservation reservation = reservationRepository.findReservationById(requestBody.getReservationId());

    List<ProgressStage> stages = stepRepository.findStagesByReservationId(requestBody.getReservationId()).stream()
            .map(ProgressStage::fromName)
            .collect(Collectors.toList());

    reservation.setProgressStage(stages.stream()
            .max(Enum::compareTo)
            .orElse(null)
            .getName()
    );

    reservationRepository.save(reservation);
}
```

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- `@Transactional`
> `@Transactional` 어노테이션은 스프링 프레임워크에서 제공하는 어노테이션으로, 트랜잭션을 지원하는 메서드에 사용됩니다. 이 어노테이션을 메서드나 클래스에 지정하면 해당 메서드나 클래스의 모든 public 메서드에 대해 트랜잭션 관리가 자동으로 적용됩니다.
>
> `@Transactional`이 없으면 메서드 실행마다 DB 작업이 각각 별개의 트랜잭션으로 처리됩니다. 각각의 DB 작업이 독립적으로 처리되면 데이터 일관성 문제가 발생할 수 있습니다. 따라서, 트랜잭션 관리가 필요한 메서드에는 `@Transactional` 어노테이션을 명시적으로 추가하는 것이 좋습니다. 이렇게 하면 해당 메서드에서 실행되는 모든 데이터베이스 작업이 하나의 트랜잭션으로 묶입니다.