### PR TITLE
[#218] 관리자 로그인, 로그아웃 API 구현

### DIFF
--- a/server/src/main/java/com/genesisairport/reservation/controller/admin/AdminAccountController.java
+++ b/server/src/main/java/com/genesisairport/reservation/controller/admin/AdminAccountController.java
@@ -26,9 +26,9 @@ public class AdminAccountController {
 
     @PostMapping("/login")
     public ResponseEntity adminLogin(@RequestBody AdminRequest.Login loginDto, HttpServletRequest request) {
-        Long id = SessionService.getAdminIdFromSession(request);
 
-        if (!adminAccountService.adminLogin(loginDto, id)) {
+        Long adminId = adminAccountService.adminLogin(loginDto);
+        if (adminId == null) {
             return new ResponseEntity<>(
                     ResponseDto.of(false, ResponseCode.BAD_REQUEST),
                     HttpStatus.OK
@@ -36,7 +36,7 @@ public class AdminAccountController {
         }
 
         HttpSession session = request.getSession(true);
-        session.setAttribute("adminId", id);
+        session.setAttribute("adminId", adminId);
         session.setMaxInactiveInterval(3600); // 1시간
 
         return new ResponseEntity(

--- a/server/src/main/java/com/genesisairport/reservation/controller/admin/AdminAccountController.java
+++ b/server/src/main/java/com/genesisairport/reservation/controller/admin/AdminAccountController.java
@@ -1,0 +1,48 @@
+package com.genesisairport.reservation.controller.admin;
+
+import com.genesisairport.reservation.common.ResponseCode;
+import com.genesisairport.reservation.common.ResponseDto;
+import com.genesisairport.reservation.request.AdminRequest;
+import com.genesisairport.reservation.service.SessionService;
+import com.genesisairport.reservation.service.admin.AdminAccountService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/v2/admin/account")
+public class AdminAccountController {
+
+    private final AdminAccountService adminAccountService;
+
+    @PostMapping("/login")
+    public ResponseEntity adminLogin(@RequestBody AdminRequest.Login loginDto, HttpServletRequest request) {
+        Long id = SessionService.getAdminIdFromSession(request);
+
+        if (!adminAccountService.adminLogin(loginDto, id)) {
+            return new ResponseEntity<>(
+                    ResponseDto.of(false, ResponseCode.BAD_REQUEST),
+                    HttpStatus.OK
+            );
+        }
+
+        HttpSession session = request.getSession(true);
+        session.setAttribute("adminId", id);
+        session.setMaxInactiveInterval(3600); // 1시간
+
+        return new ResponseEntity(
+                ResponseDto.of(true, ResponseCode.OK),
+                HttpStatus.OK
+        );
+    }
+
+}

--- a/server/src/main/java/com/genesisairport/reservation/controller/admin/AdminAccountController.java
+++ b/server/src/main/java/com/genesisairport/reservation/controller/admin/AdminAccountController.java
@@ -45,4 +45,22 @@ public class AdminAccountController {
         );
     }
 
+    @PostMapping("/logout")
+    public ResponseEntity adminLogout(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+
+        if (session != null) {
+            session.invalidate();
+            return new ResponseEntity(
+                    ResponseDto.of(true, ResponseCode.OK),
+                    HttpStatus.OK
+            );
+        }
+
+        return new ResponseEntity(
+                ResponseDto.of(true, ResponseCode.UNAUTHORIZED),
+                HttpStatus.OK
+        );
+    }
+
 }

--- a/server/src/main/java/com/genesisairport/reservation/controller/admin/AdminAccountController.java
+++ b/server/src/main/java/com/genesisairport/reservation/controller/admin/AdminAccountController.java
@@ -1,5 +1,6 @@
 package com.genesisairport.reservation.controller.admin;
 
+import com.genesisairport.reservation.common.GeneralException;
 import com.genesisairport.reservation.common.ResponseCode;
 import com.genesisairport.reservation.common.ResponseDto;
 import com.genesisairport.reservation.request.AdminRequest;
@@ -28,12 +29,6 @@ public class AdminAccountController {
     public ResponseEntity adminLogin(@RequestBody AdminRequest.Login loginDto, HttpServletRequest request) {
 
         Long adminId = adminAccountService.adminLogin(loginDto);
-        if (adminId == null) {
-            return new ResponseEntity<>(
-                    ResponseDto.of(false, ResponseCode.BAD_REQUEST),
-                    HttpStatus.OK
-            );
-        }
 
         HttpSession session = request.getSession(true);
         session.setAttribute("adminId", adminId);

--- a/server/src/main/java/com/genesisairport/reservation/entity/Admin.java
+++ b/server/src/main/java/com/genesisairport/reservation/entity/Admin.java
@@ -3,6 +3,7 @@ package com.genesisairport.reservation.entity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Getter
 public class Admin {
 
     @Id

--- a/server/src/main/java/com/genesisairport/reservation/entity/Admin.java
+++ b/server/src/main/java/com/genesisairport/reservation/entity/Admin.java
@@ -1,0 +1,36 @@
+package com.genesisairport.reservation.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "admin")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Admin {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "admin_id", nullable = false, length = 320)
+    private String adminId;
+
+    @Column(name = "admin_password", nullable = false, columnDefinition = "TEXT")
+    private String adminPassword;
+
+    @Column(name = "phone_number", nullable = false, length = 20)
+    private String phoneNumber;
+
+    @Column(name = "create_datetime", nullable = false)
+    private LocalDateTime createDatetime;
+
+    @Column(name = "update_datetime", nullable = false)
+    private LocalDateTime updateDatetime;
+
+}

--- a/server/src/main/java/com/genesisairport/reservation/entity/Admin.java
+++ b/server/src/main/java/com/genesisairport/reservation/entity/Admin.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
 
 import java.time.LocalDateTime;
 
@@ -14,6 +15,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 @Getter
+@DynamicInsert
 public class Admin {
 
     @Id
@@ -29,10 +31,10 @@ public class Admin {
     @Column(name = "phone_number", nullable = false, length = 20)
     private String phoneNumber;
 
-    @Column(name = "create_datetime", nullable = false)
+    @Column(name = "create_datetime")
     private LocalDateTime createDatetime;
 
-    @Column(name = "update_datetime", nullable = false)
+    @Column(name = "update_datetime")
     private LocalDateTime updateDatetime;
 
 }

--- a/server/src/main/java/com/genesisairport/reservation/request/AdminRequest.java
+++ b/server/src/main/java/com/genesisairport/reservation/request/AdminRequest.java
@@ -17,4 +17,14 @@ public class AdminRequest {
         private ProgressStage progress;
         private String detail;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Login {
+        private String adminId;
+        private String adminPwd;
+    }
+
 }

--- a/server/src/main/java/com/genesisairport/reservation/respository/AdminRepository.java
+++ b/server/src/main/java/com/genesisairport/reservation/respository/AdminRepository.java
@@ -1,0 +1,12 @@
+package com.genesisairport.reservation.respository;
+
+import com.genesisairport.reservation.entity.Admin;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+
+    Optional<Admin> findByAdminId(String adminId);
+
+}

--- a/server/src/main/java/com/genesisairport/reservation/service/SessionService.java
+++ b/server/src/main/java/com/genesisairport/reservation/service/SessionService.java
@@ -19,4 +19,13 @@ public class SessionService {
         }
         return null;
     }
+
+    public static Long getAdminIdFromSession(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            return (Long) session.getAttribute("adminId");
+        }
+        return null;
+    }
+
 }

--- a/server/src/main/java/com/genesisairport/reservation/service/SessionService.java
+++ b/server/src/main/java/com/genesisairport/reservation/service/SessionService.java
@@ -1,6 +1,8 @@
 package com.genesisairport.reservation.service;
 
 
+import com.genesisairport.reservation.common.GeneralException;
+import com.genesisairport.reservation.common.ResponseCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
@@ -14,18 +16,26 @@ public class SessionService {
 
     public static Long getUserIdFromSession(HttpServletRequest request) {
         HttpSession session = request.getSession(false);
-        if (session != null) {
-            return (Long) session.getAttribute("userId");
+        try {
+            if (session != null) {
+                return Long.TYPE.cast(session.getAttribute("userId"));
+            }
+            return null;
+        } catch (ClassCastException e) {
+            throw new GeneralException(ResponseCode.UNAUTHORIZED, "유저 정보가 존재하지 않습니다.");
         }
-        return null;
     }
 
     public static Long getAdminIdFromSession(HttpServletRequest request) {
         HttpSession session = request.getSession(false);
-        if (session != null) {
-            return (Long) session.getAttribute("adminId");
+        try {
+            if (session != null) {
+                return Long.TYPE.cast(session.getAttribute("adminId"));
+            }
+            return null;
+        } catch (ClassCastException e) {
+            throw new GeneralException(ResponseCode.UNAUTHORIZED, "관리자 정보가 존재하지 않습니다.");
         }
-        return null;
     }
 
 }

--- a/server/src/main/java/com/genesisairport/reservation/service/admin/AdminAccountService.java
+++ b/server/src/main/java/com/genesisairport/reservation/service/admin/AdminAccountService.java
@@ -1,5 +1,7 @@
 package com.genesisairport.reservation.service.admin;
 
+import com.genesisairport.reservation.common.GeneralException;
+import com.genesisairport.reservation.common.ResponseCode;
 import com.genesisairport.reservation.entity.Admin;
 import com.genesisairport.reservation.request.AdminRequest;
 import com.genesisairport.reservation.respository.AdminRepository;
@@ -25,12 +27,12 @@ public class AdminAccountService {
 
         // 아이디 존재 x
         if (admin == null)
-            return null;
+            throw new GeneralException(ResponseCode.BAD_REQUEST, "존재하지 않는 아이디입니다.");
 
         // 비밀번호 일치 x
         String encryptedPwd = encryptPassword(adminPwd);
         if (!admin.getAdminPassword().equals(encryptedPwd))
-            return null;
+            throw new GeneralException(ResponseCode.BAD_REQUEST, "비밀번호가 일치하지 않습니다");
 
         return admin.getId();
     }

--- a/server/src/main/java/com/genesisairport/reservation/service/admin/AdminAccountService.java
+++ b/server/src/main/java/com/genesisairport/reservation/service/admin/AdminAccountService.java
@@ -1,0 +1,60 @@
+package com.genesisairport.reservation.service.admin;
+
+import com.genesisairport.reservation.entity.Admin;
+import com.genesisairport.reservation.request.AdminRequest;
+import com.genesisairport.reservation.respository.AdminRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AdminAccountService {
+
+    private final AdminRepository adminRepository;
+
+    public boolean adminLogin(AdminRequest.Login loginDto, Long id) {
+        String adminId = loginDto.getAdminId();
+        String adminPwd = loginDto.getAdminPwd();
+
+        Admin admin = adminRepository.findByAdminId(adminId).orElse(null);
+
+        // 아이디 존재 x
+        if (admin == null)
+            return false;
+
+        // 비밀번호 일치 x
+        String encryptedPwd = encryptPassword(adminPwd);
+        if (!admin.getAdminPassword().equals(encryptedPwd))
+            return false;
+
+        // 본인 확인
+        if (admin.getId() != id)
+            return false;
+
+        return true;
+    }
+
+    private String encryptPassword(String password) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            md.update(password.getBytes());
+            byte[] hashedBytes = md.digest();
+            StringBuilder sb = new StringBuilder();
+            for (byte hashedByte : hashedBytes) {
+                sb.append(Integer.toString((hashedByte & 0xff) + 0x100, 16).substring(1));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+
+
+}

--- a/server/src/main/java/com/genesisairport/reservation/service/admin/AdminAccountService.java
+++ b/server/src/main/java/com/genesisairport/reservation/service/admin/AdminAccountService.java
@@ -17,7 +17,7 @@ public class AdminAccountService {
 
     private final AdminRepository adminRepository;
 
-    public boolean adminLogin(AdminRequest.Login loginDto, Long id) {
+    public Long adminLogin(AdminRequest.Login loginDto) {
         String adminId = loginDto.getAdminId();
         String adminPwd = loginDto.getAdminPwd();
 
@@ -25,18 +25,14 @@ public class AdminAccountService {
 
         // 아이디 존재 x
         if (admin == null)
-            return false;
+            return null;
 
         // 비밀번호 일치 x
         String encryptedPwd = encryptPassword(adminPwd);
         if (!admin.getAdminPassword().equals(encryptedPwd))
-            return false;
+            return null;
 
-        // 본인 확인
-        if (admin.getId() != id)
-            return false;
-
-        return true;
+        return admin.getId();
     }
 
     private String encryptPassword(String password) {


### PR DESCRIPTION
## ✨ 작업 내용

1. 관리자 로그인 API 구현

2. 관리자 로그아웃 API 구현

## 📎 상세 설명 (스크린샷 포함 가능)

### 관리자 로그인 API

- 아이디 존재하지 않을 때
- 비밀번호가 일치하지 않을 때

위 두 가지 경우에는 로그인이 실패한 걸로 간주하여 세션을 생성하지 않음.

로그인이 성공한 경우에는 세션 생성.

#### cf) 비밀번호 암호화

유저가 입력한 비밀번호는 SHA-256 해시 함수를 통해 암호화 한 후 DB의 값과 비교함.

### 관리자 로그아웃 API

- 세션이 존재하는 경우에는 세션 만료
- 세션이 존재하지 않으면 body에 401 코드를 담아 반환


