### PR TITLE
[#241] 테이블 및 관련 api 수정

### DIFF
--- a/client/src/components/reservation_detail/ReservationDetailResult.js
+++ b/client/src/components/reservation_detail/ReservationDetailResult.js
@@ -48,7 +48,7 @@ export default function ReservationDetailResult({ reservationDetail }) {
       const img = new Image();
       img.onload = () => resolve({ width: img.width * (400 / img.height), height: 400 });
       img.onerror = reject;
-      img.src = src;
+      img.src = src.url;
     });
   };
   const handleBeforePrev = () => {
@@ -95,7 +95,7 @@ export default function ReservationDetailResult({ reservationDetail }) {
               }}
             >
               {beforeImages.map((image, index) => (
-                <img key={index} src={image} alt={'before-'+index} style={{ height: `400px` }} />
+                <img key={index} src={image.url} alt={'before-'+index} style={{ height: `400px` }} />
               ))}
             </div>
             )}
@@ -129,7 +129,7 @@ export default function ReservationDetailResult({ reservationDetail }) {
               }}
             >
               {afterImages.map((image, index) => (
-                <img key={index} src={image} alt={'after-'+index} style={{ height: `400px` }} />
+                <img key={index} src={image.url} alt={'after-'+index} style={{ height: `400px` }} />
               ))}
             </div>
             )}

--- a/server/src/main/java/com/genesisairport/reservation/controller/admin/AReservationController.java
+++ b/server/src/main/java/com/genesisairport/reservation/controller/admin/AReservationController.java
@@ -63,13 +63,8 @@ public class AReservationController {
     }
 
     @DeleteMapping("/progress")
-    public ResponseEntity deleteStage(@RequestBody AdminRequest.StageInfo requestBody) {
-
-        if (requestBody.getProgress() == null) {
-            throw new GeneralException(ResponseCode.INTERNAL_ERROR, "유효하지 않은 진행단계입니다.");
-        }
-
-        aReservationService.deleteStage(requestBody);
+    public ResponseEntity deleteStage(@RequestParam(value = "stepId") long stepId) {
+        aReservationService.deleteStage(stepId);
         return new ResponseEntity<>(ResponseDto.of(true, ResponseCode.OK), HttpStatus.OK);
     }
 

--- a/server/src/main/java/com/genesisairport/reservation/entity/MaintenanceImage.java
+++ b/server/src/main/java/com/genesisairport/reservation/entity/MaintenanceImage.java
@@ -19,6 +19,7 @@ public class MaintenanceImage {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Getter
     private Long id;
 
     @Column(nullable = false)

--- a/server/src/main/java/com/genesisairport/reservation/entity/Step.java
+++ b/server/src/main/java/com/genesisairport/reservation/entity/Step.java
@@ -40,5 +40,6 @@ public class Step {
 
     @ManyToOne
     @JoinColumn(name = "reservation_id")
+    @Getter
     private Reservation reservation;
 }

--- a/server/src/main/java/com/genesisairport/reservation/repository/StepRepository.java
+++ b/server/src/main/java/com/genesisairport/reservation/repository/StepRepository.java
@@ -15,6 +15,8 @@ public interface StepRepository extends JpaRepository<Step, Long> {
             @Param("reservationId") Long reservation,
             @Param("stage") String progress);
 
+    Step findStepById(long stepId);
+
     @Query("SELECT s.stage FROM Step s WHERE s.reservation.id = :reservationId")
     List<String> findStagesByReservationId(@Param("reservationId") Long reservationId);
 }

--- a/server/src/main/java/com/genesisairport/reservation/response/ReservationResponse.java
+++ b/server/src/main/java/com/genesisairport/reservation/response/ReservationResponse.java
@@ -94,10 +94,17 @@ public class ReservationResponse {
         private String customerRequest;
         private List<ProgressStage> progressStage;
         private String checkupResult;
-        private List<String> beforeImages;
-        private List<String> afterImages;
+        private List<ImageContainer> beforeImages;
+        private List<ImageContainer> afterImages;
         private String managerPhoneNumber;
         private String imageUrl;
+
+        @Getter
+        @Builder
+        public static class ImageContainer {
+            private long id;
+            private String url;
+        }
 
         @Getter
         @Builder

--- a/server/src/main/java/com/genesisairport/reservation/service/ReservationService.java
+++ b/server/src/main/java/com/genesisairport/reservation/service/ReservationService.java
@@ -161,14 +161,22 @@ public class ReservationService {
         }
 
         // maintenanceImage
-        List<String> beforeImages = new ArrayList<>();
-        List<String> afterImages = new ArrayList<>();
+        List<ReservationResponse.ReservationDetail.ImageContainer> beforeImages = new ArrayList<>();
+        List<ReservationResponse.ReservationDetail.ImageContainer> afterImages = new ArrayList<>();
         List<MaintenanceImage> maintenanceImage = reservation.getMaintenanceImage();
         for (MaintenanceImage image : maintenanceImage) {
             if (image.getStatus() == 1) {
-                afterImages.add(image.getImageUrl());
+                afterImages.add(ReservationResponse.ReservationDetail.ImageContainer.builder()
+                        .id(image.getId())
+                        .url(image.getImageUrl())
+                        .build()
+                );
             } else {
-                beforeImages.add(image.getImageUrl());
+                beforeImages.add(ReservationResponse.ReservationDetail.ImageContainer.builder()
+                        .id(image.getId())
+                        .url(image.getImageUrl())
+                        .build()
+                );
             }
         }
 

--- a/server/src/main/java/com/genesisairport/reservation/service/admin/AReservationService.java
+++ b/server/src/main/java/com/genesisairport/reservation/service/admin/AReservationService.java
@@ -64,25 +64,22 @@ public class AReservationService {
             throw new GeneralException(ResponseCode.INTERNAL_ERROR, "이미 추가된 진행 단계입니다.");
         }
 
-        setLatestStage(requestBody);
+        setLatestStage(requestBody.getReservationId());
     }
 
     @Transactional
-    public void deleteStage(AdminRequest.StageInfo requestBody) {
-        Long stepId = stepRepository.findStepByReservationIdAndStage(
-                requestBody.getReservationId(),
-                requestBody.getProgress().getName()).getId();
-
+    public void deleteStage(long stepId) {
+        long reservationId = stepRepository.findStepById(stepId).getReservation().getId();
         stepRepository.deleteById(stepId);
 
-        setLatestStage(requestBody);
+        setLatestStage(reservationId);
     }
 
-    private void setLatestStage(AdminRequest.StageInfo requestBody) {
+    private void setLatestStage(long reservationId) {
         // 예약 현황 갱신
-        Reservation reservation = reservationRepository.findReservationById(requestBody.getReservationId());
+        Reservation reservation = reservationRepository.findReservationById(reservationId);
 
-        List<ProgressStage> stages = stepRepository.findStagesByReservationId(requestBody.getReservationId()).stream()
+        List<ProgressStage> stages = stepRepository.findStagesByReservationId(reservationId).stream()
                 .map(ProgressStage::fromName)
                 .collect(Collectors.toList());
 

--- a/server/src/main/java/com/genesisairport/reservation/service/admin/AReservationService.java
+++ b/server/src/main/java/com/genesisairport/reservation/service/admin/AReservationService.java
@@ -58,11 +58,8 @@ public class AReservationService {
                 .updateDatetime(LocalDateTime.now())
                 .reservation(reservationRepository.findReservationById(requestBody.getReservationId()))
                 .build();
-        try {
-            stepRepository.save(newStep);
-        } catch (Exception e) {
-            throw new GeneralException(ResponseCode.INTERNAL_ERROR, "이미 추가된 진행 단계입니다.");
-        }
+
+        stepRepository.save(newStep);
 
         setLatestStage(requestBody.getReservationId());
     }


### PR DESCRIPTION
## ✨ 작업 내용
- step 테이블에서 reservation_id와 stage 칼럼에 대한 Unique 제거

- 예약 상세 api 수정
  - 점검 이미지 id를 포함하여 반환하도록 수정
  - 관련 코드 프론트 수정

- 진행 단계 삭제 api 수정
  - request에 stepId만 전달하도록 수정
  - stepId에 해당하는 api 삭제하도록 수정

## 📎 상세 설명 (스크린샷 포함 가능)
- 예약 상세 api 수정

> 이미지 데이터를 ImageContainer로 감싸서 반환합니다.

```java
@Getter
@Builder
public static class ImageContainer {
    private long id;
    private String url;
}
```

- 진행 단계 삭제 api 수정

> stepId를 요청받고 stepId로 진행 단계를 삭제하도록 합니다.

```java
@DeleteMapping("/progress")
public ResponseEntity deleteStage(@RequestParam(value = "stepId") long stepId) {
    aReservationService.deleteStage(stepId);
    return new ResponseEntity<>(ResponseDto.of(true, ResponseCode.OK), HttpStatus.OK);
}
```

